### PR TITLE
Feat/pull to refresh

### DIFF
--- a/frontend/components/PullToRefresh.vue
+++ b/frontend/components/PullToRefresh.vue
@@ -106,11 +106,11 @@ const handleTouchStart = (event: TouchEvent) => {
       endGestureListeners();
       return;
     }
-    const t = ev.touches[0];
-    if (!t) {
+    const currentTouch = ev.touches[0];
+    if (!currentTouch) {
       return;
     }
-    const delta = t.clientY - touchStartY;
+    const delta = currentTouch.clientY - touchStartY;
     if (delta <= 0) {
       pull.value = 0;
       return;

--- a/frontend/components/PullToRefresh.vue
+++ b/frontend/components/PullToRefresh.vue
@@ -1,0 +1,170 @@
+<template>
+  <div
+    ref="scrollRootRef"
+    class="pull-to-refresh-root min-h-[100dvh] overflow-y-auto overscroll-y-contain [-webkit-overflow-scrolling:touch]"
+    @touchstart.passive="handleTouchStart"
+  >
+    <div class="flex flex-col min-h-full">
+      <div
+        class="flex shrink-0 flex-col overflow-hidden"
+        :class="{ 'transition-[height] duration-200 ease-out': !isPulling }"
+        :style="{ height: `${pull}px` }"
+        aria-hidden="true"
+      >
+        <div class="min-h-0 flex-1" />
+        <div class="flex justify-center pb-1">
+          <fa
+            icon="arrows-rotate"
+            class="text-lg text-primary"
+            :style="{ opacity: iconOpacity }"
+          />
+        </div>
+      </div>
+      <div class="flex-1 min-h-0">
+        <slot />
+      </div>
+    </div>
+    <span class="sr-only" role="status">{{ t('Pull down to refresh') }}</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue';
+
+interface Props {
+  enabled?: boolean;
+  threshold?: number;
+  maxPull?: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  enabled: true,
+  threshold: 80,
+  maxPull: 120
+});
+
+const { t } = useI18n();
+const scrollRootRef = ref<HTMLElement | null>(null);
+const pull = ref(0);
+const isPulling = ref(false);
+
+let touchStartY = 0;
+let gestureCleanup: (() => void) | null = null;
+
+const endGestureListeners = () => {
+  gestureCleanup?.();
+  gestureCleanup = null;
+};
+
+/** True when the scroller is at (or effectively at) the top; avoids iOS subpixel scrollTop. */
+const isScrollAtTop = (el: HTMLElement): boolean => {
+  return el.scrollTop <= 1;
+};
+
+const rubberBand = (delta: number): number => {
+  const raw = delta * 0.48;
+  return Math.min(props.maxPull, raw);
+};
+
+const iconOpacity = computed(() => {
+  if (props.threshold <= 0) {
+    return 0;
+  }
+  return Math.min(1, pull.value / props.threshold);
+});
+
+const handleTouchStart = (event: TouchEvent) => {
+  endGestureListeners();
+
+  if (!props.enabled) {
+    return;
+  }
+  const el = scrollRootRef.value;
+  if (!el || !isScrollAtTop(el)) {
+    return;
+  }
+  const touch = event.touches[0];
+  if (!touch) {
+    return;
+  }
+
+  touchStartY = touch.clientY;
+  pull.value = 0;
+  isPulling.value = true;
+
+  const onMove = (ev: TouchEvent) => {
+    if (!props.enabled || !isPulling.value) {
+      return;
+    }
+    const root = scrollRootRef.value;
+    if (!root) {
+      return;
+    }
+    if (!isScrollAtTop(root)) {
+      pull.value = 0;
+      isPulling.value = false;
+      endGestureListeners();
+      return;
+    }
+    const t = ev.touches[0];
+    if (!t) {
+      return;
+    }
+    const delta = t.clientY - touchStartY;
+    if (delta <= 0) {
+      pull.value = 0;
+      return;
+    }
+    ev.preventDefault();
+    pull.value = rubberBand(delta);
+  };
+
+  const onEnd = () => {
+    endGestureListeners();
+    handleTouchEnd();
+  };
+
+  document.addEventListener('touchmove', onMove, { passive: false, capture: true });
+  document.addEventListener('touchend', onEnd, { capture: true, passive: true });
+  document.addEventListener('touchcancel', onEnd, { capture: true, passive: true });
+
+  gestureCleanup = () => {
+    document.removeEventListener('touchmove', onMove, { capture: true });
+    document.removeEventListener('touchend', onEnd, { capture: true });
+    document.removeEventListener('touchcancel', onEnd, { capture: true });
+  };
+};
+
+const handleTouchEnd = () => {
+  if (!props.enabled) {
+    isPulling.value = false;
+    pull.value = 0;
+    return;
+  }
+  const wasPulling = isPulling.value;
+  const pullAtEnd = pull.value;
+  isPulling.value = false;
+  if (!wasPulling) {
+    pull.value = 0;
+    return;
+  }
+  if (pullAtEnd >= props.threshold) {
+    // Default reloadNuxtApp ttl is 10s; force avoids ignoring repeat pulls.
+    reloadNuxtApp({ persistState: false, force: true });
+  }
+  pull.value = 0;
+};
+
+onMounted(() => {
+  if (import.meta.server) {
+    return;
+  }
+  nextTick(() => {
+    scrollRootRef.value?.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+  });
+});
+
+onUnmounted(() => {
+  endGestureListeners();
+});
+</script>

--- a/frontend/composables/usePullToRefreshEnabled.ts
+++ b/frontend/composables/usePullToRefreshEnabled.ts
@@ -1,0 +1,33 @@
+import { Capacitor } from '@capacitor/core';
+
+const readPullToRefreshEnabled = (): boolean => {
+  if (!import.meta.client) {
+    return false;
+  }
+  const mq = window.matchMedia('(max-width: 768px)');
+  return Capacitor.isNativePlatform() || mq.matches;
+};
+
+export const usePullToRefreshEnabled = () => {
+  const pullToRefreshEnabled = ref(readPullToRefreshEnabled());
+  const removeMediaQueryListener = ref<(() => void) | null>(null);
+
+  onMounted(() => {
+    if (!import.meta.client) {
+      return;
+    }
+    const mq = window.matchMedia('(max-width: 768px)');
+    const sync = () => {
+      pullToRefreshEnabled.value = Capacitor.isNativePlatform() || mq.matches;
+    };
+    sync();
+    mq.addEventListener('change', sync);
+    removeMediaQueryListener.value = () => mq.removeEventListener('change', sync);
+  });
+
+  onUnmounted(() => {
+    removeMediaQueryListener.value?.();
+  });
+
+  return { pullToRefreshEnabled };
+};

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -1,4 +1,5 @@
 {
+  "Pull down to refresh": "Pull down to refresh",
   "Meal diary": "Meal diary",
   "Breakfast": "Breakfast",
   "Lunch": "Lunch",

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -32,9 +32,7 @@ export default defineNuxtConfig({
     '@fortawesome/fontawesome-svg-core/styles.css',
   ],
   vite: {
-    plugins: [
-      tailwindcss(),
-    ],
+    plugins: [tailwindcss() as any],
   },
   modules: [
     '@vesp/nuxt-fontawesome',

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -83,6 +83,7 @@ export default defineNuxtConfig({
         'magnifying-glass',
         'circle-plus',
         'circle-minus',
+        'arrows-rotate',
       ],
       brands: [],
       regular: [],

--- a/frontend/pages/diary/index.vue
+++ b/frontend/pages/diary/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="max-w-4xl mx-auto">
+  <PullToRefresh class="max-w-4xl mx-auto" :enabled="pullToRefreshEnabled">
     <h1 class="text-2xl font-bold text-center m-4" data-testid="diary-title">{{ $t('Meal diary') }}</h1>
 
     <MealDiarySkeleton v-if="!hasMealData" />
@@ -31,7 +31,7 @@
         @saveMeal="handleSaveMeal"
       />
     </dialog>
-  </div>
+  </PullToRefresh>
 </template>
 
 <script setup>
@@ -45,8 +45,11 @@ import DayFoodPlanCard from '~/components/diary/DayFoodPlanCard.vue';
 import SetUpdateMealModal from '~/components/diary/SetUpdateMealModal.vue';
 import WeekCalendarPicker from '~/components/WeekCalendarPicker.vue';
 import MealDiarySkeleton from '~/components/diary/MealDiarySkeleton.vue';
+import PullToRefresh from '~/components/PullToRefresh.vue';
 import { useDateUtils } from '~/composables/useDateUtils.ts';
+import { usePullToRefreshEnabled } from '~/composables/usePullToRefreshEnabled';
 
+const { pullToRefreshEnabled } = usePullToRefreshEnabled();
 const mealDiaryStore = useMealDiaryStore();
 const userStore = useUserStore();
 const { getDayName, getDateForDay, isDayInPast } = useDateUtils();

--- a/frontend/pages/shopping-list/index.vue
+++ b/frontend/pages/shopping-list/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="max-w-4xl mx-auto px-4">
+  <PullToRefresh class="max-w-4xl mx-auto px-4" :enabled="pullToRefreshEnabled">
     <h1 class="text-2xl font-bold text-center m-4" data-testid="shopping-list-title">
       {{ $t('Shopping List') }}
     </h1>
@@ -69,7 +69,7 @@
         </div>
       </DnDProvider>
     </div>
-  </div>
+  </PullToRefresh>
 </template>
 
 <script setup lang="ts">
@@ -81,9 +81,12 @@ import { DnDProvider } from '@vue-dnd-kit/core';
 import ShoppingListSkeleton from '~/components/shopping-list/ShoppingListSkeleton.vue';
 import ShoppingListItem from '~/components/shopping-list/ShoppingListItem.vue';
 import ShoppingListDndZone from '~/components/shopping-list/ShoppingListDndZone.vue';
+import PullToRefresh from '~/components/PullToRefresh.vue';
+import { usePullToRefreshEnabled } from '~/composables/usePullToRefreshEnabled';
 import { useShoppingListStore } from '~/stores/shoppingList';
 import { useUserStore } from '~/stores/user';
 
+const { pullToRefreshEnabled } = usePullToRefreshEnabled();
 const shoppingListStore = useShoppingListStore();
 const userStore = useUserStore();
 
@@ -306,13 +309,6 @@ onMounted(async () => {
 
 .list-item {
   transition: all 0.2s ease;
-}
-
-/* Ensure the page is scrollable and handles keyboard properly */
-.max-w-4xl {
-  min-height: 100vh;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 /* Ensure inputs are properly positioned when keyboard opens */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds global touch gesture handling and triggers `reloadNuxtApp` on pull, which can affect scrolling/gesture behavior and cause unexpected reloads on mobile devices. Changes are limited to frontend pages and configuration but should be tested across iOS/Android and desktop breakpoints.
> 
> **Overview**
> Adds a new `PullToRefresh` component that implements a touch-driven pull gesture (with a rubber-band indicator) and calls `reloadNuxtApp({ persistState: false, force: true })` once a configurable threshold is reached.
> 
> Introduces `usePullToRefreshEnabled` to enable the feature only on native platforms or small screens, and wraps the `diary` and `shopping-list` pages with this component (removing now-redundant page-level scroll CSS on shopping list). Also updates i18n (`"Pull down to refresh"`) and registers the FontAwesome `arrows-rotate` icon; Nuxt Vite Tailwind plugin config is adjusted for typing (`as any`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9548da39286472706dce5a0922d82737177febd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->