### PR TITLE
feat: legal pages, registration consent, and terms acceptance (compliance Phase 1)

### DIFF
--- a/api/controllers/user/user.controller.ts
+++ b/api/controllers/user/user.controller.ts
@@ -5,7 +5,7 @@ import * as UserService from '../../services/user.service.ts';
 // Create a new user
 export const createUser = async (req: Request, res: Response) => {
   try {
-    const { username, email, password, first_name, last_name, family_group_code, family_group_id } = req.body;
+    const { username, email, password, first_name, last_name, family_group_code, family_group_id, terms_accepted } = req.body;
 
     try {
       const { user, familyGroupId } = await UserService.createUser({
@@ -15,7 +15,8 @@ export const createUser = async (req: Request, res: Response) => {
         first_name,
         last_name,
         family_group_code,
-        family_group_id
+        family_group_id,
+        terms_accepted
       });
 
       // Track user registration

--- a/api/db/models/User.model.ts
+++ b/api/db/models/User.model.ts
@@ -12,6 +12,7 @@ export interface UserAttributes {
   last_name?: string;
   family_group_id?: number;
   avatar_url?: string;
+  terms_accepted_at?: Date;
   created_at?: Date;
   updated_at?: Date;
 }
@@ -57,6 +58,10 @@ User.init(
     },
     avatar_url: {
       type: DataTypes.STRING(255),
+      allowNull: true,
+    },
+    terms_accepted_at: {
+      type: DataTypes.DATE,
       allowNull: true,
     },
     created_at: {

--- a/api/routes/userRoutes.routes.ts
+++ b/api/routes/userRoutes.routes.ts
@@ -54,7 +54,11 @@ const router = express.Router();
  *         - username
  *         - email
  *         - password
+ *         - terms_accepted
  *       properties:
+ *         terms_accepted:
+ *           type: boolean
+ *           description: Must be true — records acceptance of the terms of service and privacy policy
  *         username:
  *           type: string
  *           maxLength: 50

--- a/api/services/__tests__/user.service.unit.test.ts
+++ b/api/services/__tests__/user.service.unit.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import User from '../../db/models/User.model.ts';
+import { createUser } from '../user.service.ts';
+
+const validInput = {
+  username: 'newuser',
+  email: 'New@Example.com',
+  password: 'password123',
+  terms_accepted: true,
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  // No existing user with the same username/email
+  vi.spyOn(User, 'findOne').mockResolvedValue(null);
+});
+
+describe('createUser', () => {
+  it('throws when username, email, or password is missing', async () => {
+    await expect(
+      createUser({ ...validInput, username: '' })
+    ).rejects.toThrow('Username, email, and password are required');
+  });
+
+  it('throws when the terms have not been accepted', async () => {
+    await expect(
+      createUser({ ...validInput, terms_accepted: false })
+    ).rejects.toThrow(
+      'Acceptance of the terms of service and privacy policy is required'
+    );
+
+    await expect(
+      createUser({ ...validInput, terms_accepted: undefined })
+    ).rejects.toThrow(
+      'Acceptance of the terms of service and privacy policy is required'
+    );
+  });
+
+  it('stores terms_accepted_at when the terms are accepted', async () => {
+    const create = vi.spyOn(User, 'create').mockResolvedValue({
+      id: 1,
+      toJSON() {
+        return { id: 1, username: 'newuser', email: 'new@example.com' };
+      },
+    } as never);
+
+    const result = await createUser(validInput);
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: 'newuser',
+        email: 'new@example.com',
+        terms_accepted_at: expect.any(Date),
+      })
+    );
+    expect(result.user).not.toHaveProperty('password_hash');
+  });
+
+  it('throws when a user with the same username or email exists', async () => {
+    vi.spyOn(User, 'findOne').mockResolvedValue({ id: 99 } as never);
+
+    await expect(createUser(validInput)).rejects.toThrow(
+      'User with this username or email already exists'
+    );
+  });
+});

--- a/api/services/auth.service.ts
+++ b/api/services/auth.service.ts
@@ -81,6 +81,9 @@ export const findOrCreateGoogleUser = async (googleProfile: GoogleProfile): Prom
       last_name: lastName,
       avatar_url: avatarUrl,
       password_hash: undefined, // Google-only account
+      // OAuth sign-up: the login screen states that continuing with Google
+      // constitutes acceptance of the terms and privacy policy
+      terms_accepted_at: new Date(),
     }) as User & UserAttributes;
   }
 

--- a/api/services/user.service.ts
+++ b/api/services/user.service.ts
@@ -11,6 +11,7 @@ export interface CreateUserData {
   last_name?: string;
   family_group_id?: number;
   family_group_code?: string;
+  terms_accepted?: boolean;
 }
 
 export interface UpdateUserData {
@@ -91,10 +92,14 @@ export const createUser = async (userData: CreateUserData): Promise<{
   user: Omit<UserAttributes, 'password_hash'>;
   familyGroupId: number | null;
 }> => {
-  const { username, email, password, first_name, last_name, family_group_id, family_group_code } = userData;
+  const { username, email, password, first_name, last_name, family_group_id, family_group_code, terms_accepted } = userData;
 
   if (!username || !email || !password) {
     throw new Error('Username, email, and password are required');
+  }
+
+  if (!terms_accepted) {
+    throw new Error('Acceptance of the terms of service and privacy policy is required');
   }
 
   // Resolve family group ID from code if provided
@@ -118,7 +123,8 @@ export const createUser = async (userData: CreateUserData): Promise<{
     password_hash: hashedPassword,
     first_name,
     last_name,
-    family_group_id: resolvedFamilyGroupId
+    family_group_id: resolvedFamilyGroupId,
+    terms_accepted_at: new Date()
   }) as User & UserAttributes;
 
   return {

--- a/frontend/components/LegalLinks.vue
+++ b/frontend/components/LegalLinks.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="flex justify-center gap-2 text-sm opacity-70">
+    <NuxtLink class="link link-hover" to="/privacy" data-testid="privacy-link">
+      {{ $t('Privacy Policy') }}
+    </NuxtLink>
+    <span>·</span>
+    <NuxtLink class="link link-hover" to="/terms" data-testid="terms-link">
+      {{ $t('Terms of Service') }}
+    </NuxtLink>
+    <span>·</span>
+    <NuxtLink class="link link-hover" to="/support" data-testid="support-link">
+      {{ $t('Support') }}
+    </NuxtLink>
+  </div>
+</template>

--- a/frontend/composables/useRegister.ts
+++ b/frontend/composables/useRegister.ts
@@ -7,6 +7,7 @@ interface RegisterData {
   last_name: string;
   password: string;
   confirm_password: string;
+  terms_accepted: boolean;
   hasErrors: boolean;
 }
 
@@ -56,6 +57,7 @@ export const useRegister = () => {
       last_name: '',
       password: '',
       confirm_password: '',
+      terms_accepted: '',
       general: ''
     });
 
@@ -94,6 +96,11 @@ export const useRegister = () => {
       errors.value.confirm_password = 'Passwords do not match';
       hasErrors = true;
     }
+
+    if (!registrationData.terms_accepted) {
+      errors.value.terms_accepted = 'You must accept the terms of service and privacy policy';
+      hasErrors = true;
+    }
   
     if (hasErrors) {
       return {
@@ -116,7 +123,8 @@ export const useRegister = () => {
           first_name: registrationData.first_name, 
           last_name: registrationData.last_name, 
           password: registrationData.password,
-          family_group_code: registerString.value
+          family_group_code: registerString.value,
+          terms_accepted: registrationData.terms_accepted
         }),
       });
   

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -94,5 +94,187 @@
   "ingredient": "ingredient",
   "ingredients": "ingredients",
   "portions": "portions",
-  "Created by": "Created by"
+  "Created by": "Created by",
+  "Privacy Policy": "Privacy Policy",
+  "Terms of Service": "Terms of Service",
+  "Support": "Support",
+  "I agree to the": "I agree to the",
+  "and": "and",
+  "You must be at least 13 years old to use Meal Diary.": "You must be at least 13 years old to use Meal Diary.",
+  "You must accept the terms of service and privacy policy": "You must accept the terms of service and privacy policy",
+  "By continuing with Google, you agree to our": "By continuing with Google, you agree to our",
+  "Last updated": "Last updated",
+  "Contact us": "Contact us",
+  "privacyPage": {
+    "intro": "This policy explains what personal data Meal Diary collects, why we collect it, and the rights you have over it. It applies to the Meal Diary apps and the website at mealdiary.co.uk.",
+    "lastUpdated": "June 2026",
+    "sections": [
+      {
+        "title": "Who we are",
+        "body": [
+          "Meal Diary is operated by [LEGAL ENTITY NAME], registered in the United Kingdom at [REGISTERED ADDRESS]. We are the data controller for the personal data described in this policy.",
+          "You can contact us about anything in this policy at support{'@'}mealdiary.co.uk."
+        ]
+      },
+      {
+        "title": "The data we collect",
+        "body": [
+          "Account data: your username, email address, first and last name, a hashed password (never your plain-text password), and an optional avatar.",
+          "If you sign in with Google, we receive your name, email address, and profile picture from Google instead of a password.",
+          "Content you create: meal plans, recipes, shopping lists, and the family group you belong to.",
+          "Usage data (only if you consent to analytics): pages viewed, features used, and a user identifier. See the Analytics section below."
+        ]
+      },
+      {
+        "title": "How and why we use your data",
+        "body": [
+          "To provide the service — creating your account, showing your meal diary, and sharing content with your family group. Legal basis: performance of a contract.",
+          "To keep the service secure — authenticating you and preventing abuse. Legal basis: legitimate interests.",
+          "To understand how the app is used and improve it — only if you opt in to analytics. Legal basis: consent, which you can withdraw at any time."
+        ]
+      },
+      {
+        "title": "Family sharing",
+        "body": [
+          "Meal Diary is built around shared family groups. Meal plans, recipes, and shopping lists you create are visible to the other members of your family group, along with your name and avatar.",
+          "If you leave a family group, content you contributed may remain available to the remaining members. You can ask us to remove it by contacting support."
+        ]
+      },
+      {
+        "title": "Third-party services",
+        "body": [
+          "Google — used for optional sign-in. Google's privacy policy applies to the data Google processes.",
+          "PostHog (EU-hosted) — used for product analytics, only when you have consented. Data is processed within the EU.",
+          "Our hosting providers store the application database and backups.",
+          "Some meal diary and shopping list updates are sent to an integration service we operate to power notifications and automations."
+        ]
+      },
+      {
+        "title": "Analytics and consent",
+        "body": [
+          "We do not load analytics until you choose to allow them. You can change your mind at any time in your profile settings, and we will stop collecting analytics data and delete your analytics profile."
+        ]
+      },
+      {
+        "title": "How long we keep your data",
+        "body": [
+          "We keep your account data for as long as your account exists. When you delete your account, your personal data is removed from our live systems promptly and from backups within 30 days.",
+          "Shared family content may be retained for the remaining members of your group, with your personal identifiers removed."
+        ]
+      },
+      {
+        "title": "Your rights",
+        "body": [
+          "You have the right to access, correct, export, and delete your personal data, to restrict or object to processing, and to withdraw consent.",
+          "You can delete your account and download your data from your profile settings, or contact us at support{'@'}mealdiary.co.uk to exercise any of these rights."
+        ]
+      },
+      {
+        "title": "International transfers",
+        "body": [
+          "We aim to keep personal data within the UK and EU. Where a service provider processes data outside the UK or EU, we use safeguards recognised under UK GDPR, such as the UK Addendum to the EU Standard Contractual Clauses."
+        ]
+      },
+      {
+        "title": "Children",
+        "body": [
+          "Meal Diary is not intended for children under 13, and you must be at least 13 years old to create an account."
+        ]
+      },
+      {
+        "title": "Changes to this policy",
+        "body": [
+          "If we make material changes to this policy, we will notify you in the app before the changes take effect."
+        ]
+      }
+    ],
+    "complaintsTitle": "Complaints",
+    "complaintsBody": "If you are unhappy with how we handle your data, please contact us first. You also have the right to complain to the UK Information Commissioner's Office (ICO):"
+  },
+  "termsPage": {
+    "intro": "These terms govern your use of the Meal Diary apps and website. By creating an account you agree to them.",
+    "lastUpdated": "June 2026",
+    "sections": [
+      {
+        "title": "About Meal Diary",
+        "body": [
+          "Meal Diary is a meal planning app operated by [LEGAL ENTITY NAME]. It lets you plan meals, manage recipes and shopping lists, and share them with a family group."
+        ]
+      },
+      {
+        "title": "Your account",
+        "body": [
+          "You must be at least 13 years old to use Meal Diary.",
+          "You are responsible for keeping your login credentials secure and for activity on your account. Provide accurate information and keep it up to date."
+        ]
+      },
+      {
+        "title": "Acceptable use",
+        "body": [
+          "Do not use Meal Diary to store or share unlawful, offensive, or infringing content, to attempt to access other users' data, or to interfere with the operation of the service."
+        ]
+      },
+      {
+        "title": "Your content and family sharing",
+        "body": [
+          "You keep ownership of the content you create. By adding content to a family group you allow the other members of that group to view and edit it as part of the service.",
+          "If you leave a group, content you contributed may remain available to the remaining members."
+        ]
+      },
+      {
+        "title": "The service",
+        "body": [
+          "Meal Diary is provided free of charge and \"as is\". We work to keep it available and your data safe, but we do not guarantee uninterrupted availability and may change or withdraw features.",
+          "We may suspend or close accounts that breach these terms."
+        ]
+      },
+      {
+        "title": "Liability",
+        "body": [
+          "Nothing in these terms limits liability that cannot be limited by law. Otherwise, we are not liable for indirect losses, loss of data caused by events outside our reasonable control, or losses arising from your breach of these terms."
+        ]
+      },
+      {
+        "title": "Ending your account",
+        "body": [
+          "You can delete your account at any time from your profile settings or at mealdiary.co.uk/delete-account. Deletion removes your personal data as described in the Privacy Policy."
+        ]
+      },
+      {
+        "title": "Changes to these terms",
+        "body": [
+          "If we make material changes to these terms, we will notify you in the app before they take effect. Continuing to use Meal Diary after that constitutes acceptance of the updated terms."
+        ]
+      },
+      {
+        "title": "Governing law",
+        "body": [
+          "These terms are governed by the law of England and Wales, and the courts of England and Wales have jurisdiction over any disputes."
+        ]
+      }
+    ]
+  },
+  "supportPage": {
+    "intro": "Need help with Meal Diary? Check the common questions below, or email us and we will get back to you.",
+    "contactBody": "For account questions, data requests, or anything else, email us at:",
+    "faqTitle": "Common questions",
+    "faqs": [
+      {
+        "q": "How do I invite someone to my family group?",
+        "a": "Open your profile, choose \"Add family member\", and share your family code or invite link. Anyone with the code can join your group when they register."
+      },
+      {
+        "q": "I forgot my password — how do I reset it?",
+        "a": "Password reset is not yet available in the app. Email us from the address on your account and we will help you regain access."
+      },
+      {
+        "q": "How do I delete my account?",
+        "a": "Account deletion is available from your profile settings. You can also email us and we will delete your account and personal data for you."
+      },
+      {
+        "q": "How do I download my data?",
+        "a": "A data export option is coming to profile settings. Until then, email us and we will send you a copy of your data."
+      }
+    ]
+  }
 }

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -63,13 +63,20 @@
             </svg>
             {{ $t('Sign in with Google') }}
           </button>
+          <p class="text-xs text-center opacity-70">
+            {{ $t('By continuing with Google, you agree to our') }}
+            <NuxtLink class="link" to="/terms">{{ $t('Terms of Service') }}</NuxtLink>
+            {{ $t('and') }}
+            <NuxtLink class="link" to="/privacy">{{ $t('Privacy Policy') }}</NuxtLink>
+          </p>
           <div class="text-center">
             <p>
-              {{ $t('Don\'t have an account?') }} 
+              {{ $t('Don\'t have an account?') }}
               <a class="link link-hover link-primary" data-testid="register-link" href="/registration/step-1">{{ $t('Register') }}</a>
             </p>
           </div>
         </form>
+        <LegalLinks class="mt-4" />
       </div>
     </div>
   </div>
@@ -80,6 +87,8 @@ definePageMeta({
   layout: false,
   middleware: ['auth']
 });
+
+import LegalLinks from '~/components/LegalLinks.vue';
 
 const { login, isLoading: isEmailLoginLoading, error: emailLoginError } = useAuth();
 const { signInWithGoogle, isLoading: isGoogleLoginLoading, error: googleLoginError } = useGoogleAuth();

--- a/frontend/pages/privacy.vue
+++ b/frontend/pages/privacy.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="min-h-screen bg-base-100">
+    <div class="max-w-2xl mx-auto px-4 py-8">
+      <div class="flex items-center justify-between mb-2">
+        <h1 class="text-2xl font-bold">{{ $t('Privacy Policy') }}</h1>
+        <button class="btn btn-ghost btn-sm" data-testid="back-button" @click="goBack">
+          {{ $t('Back') }}
+        </button>
+      </div>
+      <p class="text-sm opacity-70 mb-6">
+        {{ $t('Last updated') }}: {{ $t('privacyPage.lastUpdated') }}
+      </p>
+
+      <p class="mb-6 leading-relaxed">{{ $t('privacyPage.intro') }}</p>
+
+      <section v-for="(section, i) in sections" :key="i" class="mb-6">
+        <h2 class="text-lg font-semibold mb-2">{{ rt(section.title) }}</h2>
+        <p
+          v-for="(paragraph, j) in section.body"
+          :key="j"
+          class="mb-2 leading-relaxed"
+        >
+          {{ rt(paragraph) }}
+        </p>
+      </section>
+
+      <section class="mb-6">
+        <h2 class="text-lg font-semibold mb-2">{{ $t('privacyPage.complaintsTitle') }}</h2>
+        <p class="mb-2 leading-relaxed">
+          {{ $t('privacyPage.complaintsBody') }}
+          <a class="link link-primary" href="https://ico.org.uk/make-a-complaint/" target="_blank" rel="noopener">
+            ico.org.uk/make-a-complaint
+          </a>
+        </p>
+      </section>
+
+      <section class="mb-6">
+        <h2 class="text-lg font-semibold mb-2">{{ $t('Contact us') }}</h2>
+        <a class="link link-primary" href="mailto:support@mealdiary.co.uk">support@mealdiary.co.uk</a>
+      </section>
+
+      <LegalLinks class="mt-8" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({
+  layout: false
+});
+
+import LegalLinks from '~/components/LegalLinks.vue';
+
+const { tm, rt } = useI18n();
+const sections = computed(() => tm('privacyPage.sections'));
+
+const goBack = () => {
+  if (window.history.length > 1) {
+    window.history.back();
+  } else {
+    navigateTo('/login');
+  }
+};
+</script>

--- a/frontend/pages/profile/index.vue
+++ b/frontend/pages/profile/index.vue
@@ -23,6 +23,8 @@
 
     <LogoutButton />
 
+    <LegalLinks class="mt-8" />
+
     <InviteModal
       ref="inviteModal"
       :family-group-code="familyGroup?.random_identifier || ''"
@@ -61,6 +63,7 @@ import FamilyDetails from '~/components/profile/FamilyDetails.vue';
 import FamilyMembers from '~/components/profile/FamilyMembers.vue';
 import LogoutButton from '~/components/profile/LogoutButton.vue';
 import InviteModal from '~/components/profile/InviteModal.vue';
+import LegalLinks from '~/components/LegalLinks.vue';
 
 const userStore = useUserStore();
 const familyStore = useFamilyStore();

--- a/frontend/pages/registration/step-1.vue
+++ b/frontend/pages/registration/step-1.vue
@@ -99,20 +99,44 @@
                 {{ errors.confirm_password }}
               </div>
 
+              <p class="text-sm opacity-70 mt-4">
+                {{ $t('You must be at least 13 years old to use Meal Diary.') }}
+              </p>
+
+              <label class="label cursor-pointer justify-start gap-3 mt-2">
+                <input
+                  type="checkbox"
+                  v-model="terms_accepted"
+                  class="checkbox checkbox-primary"
+                  data-testid="terms-checkbox"
+                  :disabled="isLoading"
+                />
+                <span class="label-text">
+                  {{ $t('I agree to the') }}
+                  <NuxtLink class="link link-primary" to="/terms" target="_blank">{{ $t('Terms of Service') }}</NuxtLink>
+                  {{ $t('and') }}
+                  <NuxtLink class="link link-primary" to="/privacy" target="_blank">{{ $t('Privacy Policy') }}</NuxtLink>
+                </span>
+              </label>
+              <div v-if="errors.terms_accepted" class="text-error text-sm mt-1" data-testid="terms-error">
+                {{ errors.terms_accepted }}
+              </div>
+
               <div v-if="errors.general" class="text-error text-center mt-4">
                 {{ errors.general }}
               </div>
 
-              <button 
-                type="submit" 
+              <button
+                type="submit"
                 class="btn btn-primary w-full mt-4"
                 :disabled="isLoading"
               >
                 <span v-if="isLoading" class="loading loading-spinner loading-sm"></span>
                 <span v-else>{{ $t('Register') }}</span>
               </button>
-            </div> 
+            </div>
           </form>
+          <LegalLinks class="mt-4" />
         </div>
       </div>
     </div>
@@ -124,6 +148,8 @@ definePageMeta({
   layout: false
 });
 
+import LegalLinks from '~/components/LegalLinks.vue';
+
 const { performRegistration, storeRegisterString, deleteRegisterString } = useRegister();
 
 const username = ref('');
@@ -132,6 +158,7 @@ const last_name = ref('');
 const password = ref('');
 const confirm_password = ref('');
 const email = ref('');
+const terms_accepted = ref(false);
 const isLoading = ref(false);
 
 const errors = ref({
@@ -141,6 +168,7 @@ const errors = ref({
   last_name: '',
   password: '',
   confirm_password: '',
+  terms_accepted: '',
   general: ''
 });
 
@@ -152,6 +180,7 @@ const clearErrors = () => {
     last_name: '',
     password: '',
     confirm_password: '',
+    terms_accepted: '',
     general: ''
   };
 };
@@ -175,7 +204,8 @@ const handleRegistration = async () => {
       first_name: first_name.value,
       last_name: last_name.value,
       password: password.value,
-      confirm_password: confirm_password.value
+      confirm_password: confirm_password.value,
+      terms_accepted: terms_accepted.value
     });
 
     if (result.hasErrors) {

--- a/frontend/pages/support.vue
+++ b/frontend/pages/support.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="min-h-screen bg-base-100">
+    <div class="max-w-2xl mx-auto px-4 py-8">
+      <div class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-bold">{{ $t('Support') }}</h1>
+        <button class="btn btn-ghost btn-sm" data-testid="back-button" @click="goBack">
+          {{ $t('Back') }}
+        </button>
+      </div>
+
+      <p class="mb-6 leading-relaxed">{{ $t('supportPage.intro') }}</p>
+
+      <div class="card bg-base-200 mb-8">
+        <div class="card-body">
+          <h2 class="card-title text-lg">{{ $t('Contact us') }}</h2>
+          <p>{{ $t('supportPage.contactBody') }}</p>
+          <a
+            class="link link-primary text-lg"
+            href="mailto:support@mealdiary.co.uk"
+            data-testid="support-email"
+          >
+            support@mealdiary.co.uk
+          </a>
+        </div>
+      </div>
+
+      <h2 class="text-lg font-semibold mb-4">{{ $t('supportPage.faqTitle') }}</h2>
+      <div
+        v-for="(faq, i) in faqs"
+        :key="i"
+        class="collapse collapse-arrow bg-base-200 mb-2"
+      >
+        <input type="radio" name="support-faq" />
+        <div class="collapse-title font-medium">{{ rt(faq.q) }}</div>
+        <div class="collapse-content">
+          <p class="leading-relaxed">{{ rt(faq.a) }}</p>
+        </div>
+      </div>
+
+      <LegalLinks class="mt-8" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({
+  layout: false
+});
+
+import LegalLinks from '~/components/LegalLinks.vue';
+
+const { tm, rt } = useI18n();
+const faqs = computed(() => tm('supportPage.faqs'));
+
+const goBack = () => {
+  if (window.history.length > 1) {
+    window.history.back();
+  } else {
+    navigateTo('/login');
+  }
+};
+</script>

--- a/frontend/pages/terms.vue
+++ b/frontend/pages/terms.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="min-h-screen bg-base-100">
+    <div class="max-w-2xl mx-auto px-4 py-8">
+      <div class="flex items-center justify-between mb-2">
+        <h1 class="text-2xl font-bold">{{ $t('Terms of Service') }}</h1>
+        <button class="btn btn-ghost btn-sm" data-testid="back-button" @click="goBack">
+          {{ $t('Back') }}
+        </button>
+      </div>
+      <p class="text-sm opacity-70 mb-6">
+        {{ $t('Last updated') }}: {{ $t('termsPage.lastUpdated') }}
+      </p>
+
+      <p class="mb-6 leading-relaxed">{{ $t('termsPage.intro') }}</p>
+
+      <section v-for="(section, i) in sections" :key="i" class="mb-6">
+        <h2 class="text-lg font-semibold mb-2">{{ rt(section.title) }}</h2>
+        <p
+          v-for="(paragraph, j) in section.body"
+          :key="j"
+          class="mb-2 leading-relaxed"
+        >
+          {{ rt(paragraph) }}
+        </p>
+      </section>
+
+      <section class="mb-6">
+        <h2 class="text-lg font-semibold mb-2">{{ $t('Contact us') }}</h2>
+        <a class="link link-primary" href="mailto:support@mealdiary.co.uk">support@mealdiary.co.uk</a>
+      </section>
+
+      <LegalLinks class="mt-8" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({
+  layout: false
+});
+
+import LegalLinks from '~/components/LegalLinks.vue';
+
+const { tm, rt } = useI18n();
+const sections = computed(() => tm('termsPage.sections'));
+
+const goBack = () => {
+  if (window.history.length > 1) {
+    window.history.back();
+  } else {
+    navigateTo('/login');
+  }
+};
+</script>


### PR DESCRIPTION
## What

Phase 1 of the app store compliance plan — public legal pages and registration consent. Unblocks milestone M1 (privacy/support URLs for App Store Connect and Play Console drafts).

### Public pages (no auth required)
- **/privacy** — privacy policy covering data categories, lawful bases, family sharing, third parties (Google, PostHog EU, hosting, webhook integration), retention, GDPR rights, international transfers, 13+ age rule, and ICO complaints link
- **/terms** — terms of service (accounts, acceptable use, family-shared content, liability, governing law England & Wales)
- **/support** — contact email + FAQ accordion
- All copy lives in `i18n/locales/en.json` under structured namespaces and renders via `tm()`/`rt()`; email addresses escaped as `{'@'}` for the vue-i18n message compiler

### Consent at registration
- New `LegalLinks` component on login, registration step-1, and profile
- Registration step-1: required "I agree to the Terms of Service and Privacy Policy" checkbox (links open in new tab), "You must be at least 13 years old" statement, client-side validation
- Login: "By continuing with Google, you agree to…" notice covering OAuth sign-ups

### API
- `terms_accepted_at` column added to the User model (created automatically by `sequelize.sync({ alter: true })` on next API start)
- `POST /users` now returns `400` unless `terms_accepted: true` is sent; timestamp stored on creation
- Google sign-ups (`findOrCreateGoogleUser`) stamp `terms_accepted_at` at account creation, backed by the login-screen notice
- OpenAPI schema updated

## Testing

- `npm run test:unit`: 83/83 green, including 4 new tests for the createUser terms requirement
- `npx tsc --noEmit` clean

## Notes for review

- The privacy policy contains `[LEGAL ENTITY NAME]` and `[REGISTERED ADDRESS]` placeholders — these must be filled in before store submission, and the text needs solicitor review (draft + open questions in local `docs/privacy-policy-draft.md`, which is gitignored)
- `support@mealdiary.co.uk` is referenced throughout — the mailbox needs to exist before the support URL goes into the store consoles
- The support FAQ mentions account deletion and data export in settings — those ship in Phases 2 and 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
