### PR TITLE
fix: consent banner labels, theme, and remove floating launcher

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -10,3 +10,31 @@
     display: none;
   }
 }
+
+/* --------------------------------------------------------------------------
+   Silktide Consent Manager — theme to match the daisyUI theme.
+   The library exposes these variables on #stcm-wrapper; we point them at the
+   app's daisyUI tokens. `html` prefix raises specificity above the library's
+   own stylesheet (loaded dynamically after this one).
+   -------------------------------------------------------------------------- */
+html #stcm-wrapper {
+  --primaryColor: var(--color-primary);
+  --backgroundColor: var(--color-base-100);
+  --textColor: var(--color-base-content);
+  --iconBackgroundColor: var(--color-primary);
+  --iconColor: var(--color-primary-content);
+  --backdropBackgroundColor: oklch(0% 0 0 / 0.5);
+  --boxShadow: 0 10px 25px -5px oklch(0% 0 0 / 0.3);
+  --fontFamily: inherit;
+}
+
+/* Primary buttons: use readable on-primary text from the theme */
+html #stcm-wrapper .stcm-button-primary {
+  color: var(--color-primary-content);
+}
+
+/* The floating cookie launcher is replaced by the Profile → "Cookie
+   preferences" button, so hide it on every screen size. */
+#stcm-icon {
+  display: none !important;
+}

--- a/frontend/plugins/silktide-consent.client.ts
+++ b/frontend/plugins/silktide-consent.client.ts
@@ -62,7 +62,6 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     // Re-show the banner until a choice is made
     autoShow: true,
     position: { banner: 'bottomLeft' },
-    cookieIcon: { position: 'bottomLeft' },
     text: {
       banner: {
         description:
@@ -80,7 +79,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     consentTypes: [
       {
         id: 'necessary',
-        name: 'Essential',
+        label: 'Essential',
         description:
           'Required for Meal Diary to work — signing in, saving your meal plans, and keeping the app secure.',
         required: true,
@@ -88,7 +87,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       },
       {
         id: 'analytics',
-        name: 'Analytics',
+        label: 'Analytics',
         description:
           'Helps us understand how the app is used so we can improve it. No analytics run until you allow them.',
         defaultValue: false,


### PR DESCRIPTION
- Use `label` (not `name`) for Silktide consent types — fixes the "undefined" headings in the preferences modal
- Theme the banner/modal to the daisyUI theme by overriding Silktide's CSS variables on #stcm-wrapper with the app's --color-* tokens
- Hide the floating bottom-left cookie icon (#stcm-icon); the Profile "Cookie preferences" button is the single entry point on mobile and desktop