### PR TITLE
fix: pass GA_MEASUREMENT_ID to the frontend prod build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,6 +9,7 @@ COPY package*.json ./
 ARG GOOGLE_CLIENT_ID
 ARG BASE_URL=https://api.mealdiary.co.uk
 ARG ORIGIN
+ARG GA_MEASUREMENT_ID
 
 # Set as environment variables for the build process
 ENV HOST=0.0.0.0
@@ -16,6 +17,7 @@ ENV PORT=3000
 ENV BASE_URL=${BASE_URL}
 ENV GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
 ENV ORIGIN=${ORIGIN}
+ENV GA_MEASUREMENT_ID=${GA_MEASUREMENT_ID}
 
 RUN npm install
 


### PR DESCRIPTION
GA4 never fired in production because the value was baked as an empty string at build time. The prod Dockerfile bakes public env vars via ARG/ENV (GOOGLE_CLIENT_ID, BASE_URL, ORIGIN) but omitted GA_MEASUREMENT_ID, so config.public.gaMeasurementId resolved to '' and initGa() bailed early. Add GA_MEASUREMENT_ID as a build arg so Railway bakes it in like the others.