### PR TITLE
feat: GDPR data export — GET /users/me/export + Download my data (compliance Phase 6)

### DIFF
--- a/api/controllers/user/user.controller.ts
+++ b/api/controllers/user/user.controller.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from 'express';
 import { trackEvent, getDistinctId } from '../../utils/posthog.ts';
 import * as UserService from '../../services/user.service.ts';
+import * as DataExportService from '../../services/dataExport.service.ts';
 
 // Create a new user
 export const createUser = async (req: Request, res: Response) => {
@@ -151,5 +152,26 @@ export const deleteOwnAccount = async (req: Request, res: Response) => {
   } catch (error) {
     console.error('Error deleting account:', error);
     return res.status(500).json({ message: 'Failed to delete account' });
+  }
+};
+
+// Export all data linked to the authenticated user (GDPR Art. 15 / 20)
+export const exportOwnData = async (req: Request, res: Response) => {
+  try {
+    const userId = (req.user as { dataValues: { id: number } }).dataValues.id;
+
+    const data = await DataExportService.exportUserData(userId);
+
+    const filename = `meal-diary-export-${new Date().toISOString().slice(0, 10)}.json`;
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    return res.status(200).send(JSON.stringify(data, null, 2));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to export data';
+    if (message.includes('not found')) {
+      return res.status(404).json({ message });
+    }
+    console.error('Error exporting user data:', error);
+    return res.status(500).json({ message: 'Failed to export data' });
   }
 };

--- a/api/routes/__tests__/authorization.unit.test.ts
+++ b/api/routes/__tests__/authorization.unit.test.ts
@@ -13,6 +13,10 @@ vi.mock('../../services/user.service.ts', () => ({
   deleteUserAccount: vi.fn(),
 }));
 
+vi.mock('../../services/dataExport.service.ts', () => ({
+  exportUserData: vi.fn(),
+}));
+
 vi.mock('../../services/recipe.service.ts', () => ({
   getRecipesByFamilyGroup: vi.fn(),
   getRecipeById: vi.fn(),
@@ -67,6 +71,7 @@ import {
 } from '../../db/models/associations.ts';
 import ShoppingList from '../../db/models/ShoppingList.model.ts';
 import * as UserService from '../../services/user.service.ts';
+import * as DataExportService from '../../services/dataExport.service.ts';
 import * as FamilyGroupService from '../../services/familyGroup.service.ts';
 import * as RecipeService from '../../services/recipe.service.ts';
 import * as ShoppingListService from '../../services/shoppingList.service.ts';
@@ -199,6 +204,43 @@ describe('DELETE /users/me', () => {
       .send({ password: 'correct-password' });
 
     expect(res.status).toBe(409);
+  });
+});
+
+describe('GET /users/me/export', () => {
+  const bundle = {
+    exportedAt: '2026-06-14T00:00:00.000Z',
+    user: { id: 1, email: 'jake@example.com' },
+    familyGroup: null,
+    recipes: [],
+    mealDiaries: [],
+    shoppingLists: [],
+  };
+
+  it('rejects unauthenticated requests', async () => {
+    const res = await request(app).get('/users/me/export');
+    expect(res.status).toBe(401);
+    expect(DataExportService.exportUserData).not.toHaveBeenCalled();
+  });
+
+  it('returns the export for the authenticated user as a JSON attachment', async () => {
+    vi.mocked(DataExportService.exportUserData).mockResolvedValue(bundle as never);
+
+    const res = await request(app).get('/users/me/export').set(auth);
+
+    expect(res.status).toBe(200);
+    expect(DataExportService.exportUserData).toHaveBeenCalledWith(1);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.headers['content-disposition']).toMatch(/attachment; filename=/);
+    expect(res.body).toMatchObject({ exportedAt: expect.any(String), user: { id: 1 } });
+    expect(JSON.stringify(res.body)).not.toContain('password_hash');
+  });
+
+  it('maps a missing user to 404', async () => {
+    vi.mocked(DataExportService.exportUserData).mockRejectedValue(new Error('User not found'));
+
+    const res = await request(app).get('/users/me/export').set(auth);
+    expect(res.status).toBe(404);
   });
 });
 

--- a/api/routes/userRoutes.routes.ts
+++ b/api/routes/userRoutes.routes.ts
@@ -218,6 +218,50 @@ router.delete('/me', authenticateToken, async (req, res, next) => {
 
 /**
  * @openapi
+ * /users/me/export:
+ *   get:
+ *     summary: Export all data linked to the authenticated user (GDPR Art. 15/20)
+ *     tags: [Users]
+ *     responses:
+ *       200:
+ *         description: JSON attachment containing the user's profile and family-group data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 exportedAt:
+ *                   type: string
+ *                   format: date-time
+ *                 user:
+ *                   type: object
+ *                 familyGroup:
+ *                   type: object
+ *                   nullable: true
+ *                 recipes:
+ *                   type: array
+ *                   items: { type: object }
+ *                 mealDiaries:
+ *                   type: array
+ *                   items: { type: object }
+ *                 shoppingLists:
+ *                   type: array
+ *                   items: { type: object }
+ *       401:
+ *         description: Unauthorized
+ *       500:
+ *         description: Failed to export data
+ */
+router.get('/me/export', authenticateToken, async (req, res, next) => {
+  try {
+    await userController.exportOwnData(req, res);
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * @openapi
  * /users/{id}:
  *   get:
  *     summary: Get a user by id (own account only)

--- a/api/services/__tests__/dataExport.service.unit.test.ts
+++ b/api/services/__tests__/dataExport.service.unit.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  User,
+  FamilyGroup,
+  MealDiary,
+  ShoppingList,
+  Recipe,
+} from '../../db/models/associations.ts';
+import { exportUserData } from '../dataExport.service.ts';
+
+const userRow = (overrides: Record<string, unknown> = {}) => ({
+  dataValues: { id: 1, family_group_id: 7, ...overrides },
+  toJSON() {
+    return {
+      id: 1,
+      username: 'jake',
+      email: 'jake@example.com',
+      password_hash: 'super-secret-hash',
+      family_group_id: 7,
+      ...overrides,
+    };
+  },
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('exportUserData', () => {
+  it('throws when the user does not exist', async () => {
+    vi.spyOn(User, 'findByPk').mockResolvedValue(null);
+    await expect(exportUserData(1)).rejects.toThrow('User not found');
+  });
+
+  it('returns all top-level keys and never includes password_hash', async () => {
+    vi.spyOn(User, 'findByPk').mockResolvedValue(userRow() as never);
+    vi.spyOn(FamilyGroup, 'findByPk').mockResolvedValue({
+      toJSON: () => ({ id: 7, name: 'Reeves Mead' }),
+    } as never);
+    vi.spyOn(Recipe, 'findAll').mockResolvedValue([
+      { toJSON: () => ({ id: 1, name: 'Soup' }) },
+    ] as never);
+    vi.spyOn(MealDiary, 'findAll').mockResolvedValue([
+      { toJSON: () => ({ id: 1, week_start_date: '2026-06-08' }) },
+    ] as never);
+    vi.spyOn(ShoppingList, 'findAll').mockResolvedValue([
+      { toJSON: () => ({ id: 1, family_group_id: 7 }) },
+    ] as never);
+
+    const result = await exportUserData(1);
+
+    expect(Object.keys(result).sort()).toEqual(
+      ['exportedAt', 'familyGroup', 'mealDiaries', 'recipes', 'shoppingLists', 'user'].sort()
+    );
+    expect(result.exportedAt).toEqual(expect.any(String));
+    expect(result.user).not.toHaveProperty('password_hash');
+    expect(result.user.email).toBe('jake@example.com');
+    expect(result.familyGroup).toMatchObject({ name: 'Reeves Mead' });
+    expect(result.recipes).toHaveLength(1);
+    expect(result.mealDiaries).toHaveLength(1);
+    expect(result.shoppingLists).toHaveLength(1);
+  });
+
+  it('returns empty collections and null family for a user with no family group', async () => {
+    vi.spyOn(User, 'findByPk').mockResolvedValue(
+      userRow({ family_group_id: null }) as never
+    );
+    const familyFind = vi.spyOn(FamilyGroup, 'findByPk');
+    const recipeFind = vi.spyOn(Recipe, 'findAll');
+
+    const result = await exportUserData(1);
+
+    expect(result.familyGroup).toBeNull();
+    expect(result.recipes).toEqual([]);
+    expect(result.mealDiaries).toEqual([]);
+    expect(result.shoppingLists).toEqual([]);
+    // No family group → no family-scoped queries at all
+    expect(familyFind).not.toHaveBeenCalled();
+    expect(recipeFind).not.toHaveBeenCalled();
+    expect(result.user).not.toHaveProperty('password_hash');
+  });
+});

--- a/api/services/dataExport.service.ts
+++ b/api/services/dataExport.service.ts
@@ -1,0 +1,88 @@
+import {
+  User,
+  FamilyGroup,
+  MealDiary,
+  DailyMeal,
+  ShoppingList,
+  ShoppingListCategory,
+  ShoppingListItem,
+  ItemCategory,
+  Recipe,
+  RecipeIngredient,
+} from '../db/models/associations.ts';
+
+export interface UserDataExport {
+  exportedAt: string;
+  user: Record<string, any>;
+  familyGroup: Record<string, any> | null;
+  recipes: Record<string, any>[];
+  mealDiaries: Record<string, any>[];
+  shoppingLists: Record<string, any>[];
+}
+
+/**
+ * Build a machine-readable export of everything linked to a user (GDPR
+ * Art. 15 access / Art. 20 portability): their profile plus the data in the
+ * family group they belong to. Credentials are never included — password_hash
+ * is stripped and refresh tokens are not queried.
+ */
+export const exportUserData = async (userId: number): Promise<UserDataExport> => {
+  const user = await User.findByPk(userId);
+  if (!user) {
+    throw new Error('User not found');
+  }
+
+  const userJson = user.toJSON() as Record<string, any>;
+  delete userJson.password_hash;
+
+  const familyGroupId = user.dataValues.family_group_id;
+
+  let familyGroup: Record<string, any> | null = null;
+  let recipes: Record<string, any>[] = [];
+  let mealDiaries: Record<string, any>[] = [];
+  let shoppingLists: Record<string, any>[] = [];
+
+  if (familyGroupId) {
+    const group = await FamilyGroup.findByPk(familyGroupId);
+    familyGroup = group ? (group.toJSON() as Record<string, any>) : null;
+
+    const recipeRows = await Recipe.findAll({
+      where: { family_group_id: familyGroupId },
+      include: [{ model: RecipeIngredient, as: 'ingredients' }],
+      order: [['name', 'ASC']],
+    });
+    recipes = recipeRows.map((r) => r.toJSON() as Record<string, any>);
+
+    const mealDiaryRows = await MealDiary.findAll({
+      where: { family_group_id: familyGroupId },
+      include: [{ model: DailyMeal }],
+      order: [['week_start_date', 'ASC']],
+    });
+    mealDiaries = mealDiaryRows.map((d) => d.toJSON() as Record<string, any>);
+
+    const shoppingListRows = await ShoppingList.findAll({
+      where: { family_group_id: familyGroupId },
+      include: [
+        {
+          model: ShoppingListCategory,
+          as: 'categories',
+          include: [
+            { model: ItemCategory, as: 'itemCategory' },
+            { model: ShoppingListItem, as: 'items' },
+          ],
+        },
+        { model: ShoppingListItem, as: 'items' },
+      ],
+    });
+    shoppingLists = shoppingListRows.map((s) => s.toJSON() as Record<string, any>);
+  }
+
+  return {
+    exportedAt: new Date().toISOString(),
+    user: userJson,
+    familyGroup,
+    recipes,
+    mealDiaries,
+    shoppingLists,
+  };
+};

--- a/frontend/components/profile/AccountSettings.vue
+++ b/frontend/components/profile/AccountSettings.vue
@@ -8,6 +8,15 @@
       <div class="card-actions mt-auto">
         <LogoutButton />
         <button
+          class="btn btn-ghost"
+          data-testid="download-data-button"
+          :disabled="isExporting"
+          @click="handleDownloadData"
+        >
+          <span v-if="isExporting" class="loading loading-spinner loading-sm"></span>
+          <span v-else>{{ $t('Download my data') }}</span>
+        </button>
+        <button
           v-if="canManageCookies"
           class="btn btn-ghost"
           data-testid="manage-cookies-button"
@@ -91,17 +100,48 @@
 import { useUserStore } from '~/stores/user';
 import { useAuthStore } from '~/stores/auth';
 import LogoutButton from '~/components/profile/LogoutButton.vue';
+import { useToast } from '~/composables/useToast';
 
 const { t } = useI18n();
 const userStore = useUserStore();
 const authStore = useAuthStore();
 const { api } = useApi();
+const { showError } = useToast();
 
 // Provided by the Silktide consent plugin (absent in dev / if it fails to load)
 const { $openCookiePreferences } = useNuxtApp();
 const canManageCookies = computed(() => typeof $openCookiePreferences === 'function');
 const openCookiePreferences = () => {
   if (typeof $openCookiePreferences === 'function') $openCookiePreferences();
+};
+
+// Download my data (GDPR Art. 15/20) — fetch the JSON bundle via the api
+// composable (carries the bearer token) and save it client-side as a file.
+const isExporting = ref(false);
+const handleDownloadData = async () => {
+  if (isExporting.value) return;
+  isExporting.value = true;
+  try {
+    const response = await api('/api/user/me/export');
+    // Proxy returns ApiResponse { data, headers }; unwrap to the bundle
+    const bundle = response?.data ?? response;
+    const json = JSON.stringify(bundle, null, 2);
+
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `meal-diary-export-${new Date().toISOString().slice(0, 10)}.json`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  } catch (err) {
+    showError(t('Failed to download your data'));
+    console.error('Data export failed:', err);
+  } finally {
+    isExporting.value = false;
+  }
 };
 
 const modal = ref(null);

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -128,6 +128,8 @@
   "Failed to delete family group": "Failed to delete family group",
   "Account": "Account",
   "Cookie preferences": "Cookie preferences",
+  "Download my data": "Download my data",
+  "Failed to download your data": "Failed to download your data",
   "Delete account": "Delete account",
   "Deleting your account is permanent and cannot be undone.": "Deleting your account is permanent and cannot be undone.",
   "This will permanently delete:": "This will permanently delete:",

--- a/frontend/server/api/user/me/export.get.ts
+++ b/frontend/server/api/user/me/export.get.ts
@@ -1,0 +1,15 @@
+import { authenticatedFetch } from '~/server/utils/auth';
+
+// Proxies the export bundle through with auth/token-refresh handling. The
+// client fetches this via the api composable (which carries the bearer token)
+// and triggers a Blob download, so no download headers are needed here.
+export default defineEventHandler(async (event) => {
+  try {
+    return await authenticatedFetch(event, '/users/me/export');
+  } catch (error: any) {
+    throw createError({
+      statusCode: error.statusCode || 500,
+      message: error.message || 'Failed to export data',
+    });
+  }
+});


### PR DESCRIPTION
## What

Phase 6 of the app store compliance plan — **GDPR data export** (Art. 15 access / Art. 20 portability). Synchronous in-app download (chosen over async+email, since this app's export is small).

### API
- **`dataExport.service.exportUserData`** — assembles a JSON bundle: the user's profile plus the data in their family group (family group, recipes + ingredients, meal diaries + daily meals, shopping lists with categories/items). **`password_hash` is stripped; refresh tokens are never queried.** Users with no family group get `null`/empty collections.
- **`GET /users/me/export`** — returns the bundle as a JSON attachment (`Content-Disposition`), registered before `/:id`.

### Frontend
- Nuxt proxy `server/api/user/me/export.get.ts` (token-refresh aware).
- **"Download my data"** button in the Account settings card — fetches via the `api` composable (which carries the bearer token) and triggers a client-side **Blob download**. This is the correct pattern for header-based auth: a plain link wouldn't carry the `Authorization` header.

## Testing

- `npm run test:unit`: **118/118 green** — 6 new tests:
  - Service: all top-level keys present, `password_hash` excluded, no-family-group path returns null/empty and runs no family-scoped queries, missing user throws.
  - Route: `401` unauthenticated, `200` returns JSON attachment with `Content-Disposition`, body contains no `password_hash`, missing user maps to `404`.
- `npx tsc --noEmit` clean; frontend compiles (verified via HMR — Nitro picked up the new proxy route).

## Notes for review

- Export includes **family-shared data** the user has access to (recipes, meal diaries, shopping lists), which is appropriate for Art. 20 portability of data they contributed to / can access.
- This is a **synchronous** download. We discussed async+worker+email and confirmed it's also compliant, but it's unnecessary for this app's data volume and would add a job queue + email provider + signed-link infra. Easy to revisit later if real exports ever grow large.
- The privacy policy already states users can download their data from settings — this fulfils that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
