### PR TITLE
fix: production build failure — TS annotations in plain-JS AccountSettings script

### DIFF
--- a/frontend/components/profile/AccountSettings.vue
+++ b/frontend/components/profile/AccountSettings.vue
@@ -122,7 +122,7 @@ const openCookiePreferences = () => {
 // native we write the file and open the share sheet instead.
 const isExporting = ref(false);
 
-const saveOnWeb = (json: string, filename: string) => {
+const saveOnWeb = (json, filename) => {
   const blob = new Blob([json], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
@@ -134,7 +134,7 @@ const saveOnWeb = (json: string, filename: string) => {
   URL.revokeObjectURL(url);
 };
 
-const saveOnNative = async (json: string, filename: string) => {
+const saveOnNative = async (json, filename) => {
   const { Filesystem, Directory, Encoding } = await import('@capacitor/filesystem');
   const { Share } = await import('@capacitor/share');
 


### PR DESCRIPTION
## What

Fixes a **production build failure on `main`** introduced by the Phase 6 data-export PR (#78).

The data-export helpers in `AccountSettings.vue` used TypeScript type annotations — `(json: string, filename: string)` — inside a `<script setup>` block that is **not** `lang="ts"`. Dev's esbuild tolerated it, but the production Vue SFC compiler rejects it:

```
Nuxt build error: SyntaxError: [vite:vue] [vue/compiler-sfc] Unexpected token, expected "," (27:23)
  /app/components/profile/AccountSettings.vue
  125| const saveOnWeb = (json: string, filename: string) => {
```

The fix drops the annotations to match the file's existing plain-JS style. Behaviour is unchanged.

## Why a separate PR

The bug landed on `main` via #78 before the fix was committed, so `main`'s build is currently broken. This is a clean single-commit branch cut from current `main`.

## Notes for review

- Only `AccountSettings.vue` was affected — the other files touched in Phase 4/6 either only received `track()` calls (no annotations) or are already `lang="ts"`.
- Process note: this class of error isn't caught by dev HMR (esbuild is lenient); running `npm run build` in CI before merge would catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
