### PR TITLE
fix(user model): change avatar_url type to TEXT for longer URLs

### DIFF
--- a/api/db/models/User.model.ts
+++ b/api/db/models/User.model.ts
@@ -57,7 +57,7 @@ User.init(
       allowNull: true,
     },
     avatar_url: {
-      type: DataTypes.STRING(255),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     terms_accepted_at: {

--- a/api/db/models/__tests__/User.unit.test.ts
+++ b/api/db/models/__tests__/User.unit.test.ts
@@ -56,4 +56,14 @@ describe('User Model', () => {
 
     await expect(user.validate()).resolves.not.toThrow();
   });
+
+  it('should allow long avatar URLs (e.g. Google profile picture links)', async () => {
+    const user = User.build({
+      username: 'vitest_test_long_avatar',
+      email: 'vitest_test_long_avatar@example.com',
+      avatar_url: `https://lh3.googleusercontent.com/a/${'x'.repeat(400)}`,
+    });
+
+    await expect(user.validate()).resolves.not.toThrow();
+  });
 });

--- a/api/utils/__tests__/posthog.unit.test.ts
+++ b/api/utils/__tests__/posthog.unit.test.ts
@@ -51,4 +51,11 @@ describe('sanitizeErrorForAnalytics', () => {
     const result = sanitizeErrorForAnalytics(error);
     expect(result.error_type).toBe('db_error');
   });
+
+  it('classifies postgres varchar length errors', () => {
+    const result = sanitizeErrorForAnalytics(
+      new Error('value too long for type character varying(255)')
+    );
+    expect(result.error_type).toBe('db_error');
+  });
 });

--- a/api/utils/posthog.ts
+++ b/api/utils/posthog.ts
@@ -74,7 +74,8 @@ const classifyErrorType = (message: string, errorName?: string): string => {
     errorName === 'SequelizeValidationError' ||
     errorName === 'SequelizeUniqueConstraintError' ||
     lower.includes('unique violation') ||
-    lower.includes('validation error')
+    lower.includes('validation error') ||
+    lower.includes('value too long for type character varying')
   ) {
     return 'db_error';
   }


### PR DESCRIPTION
- Updated the `avatar_url` field in the User model to use `DataTypes.TEXT` instead of `DataTypes.STRING(255)` to accommodate longer URLs.
- Added a unit test to validate that long avatar URLs are accepted without throwing errors.
- Enhanced error classification in the error handling utility to include specific handling for PostgreSQL varchar length errors.