### PR TITLE
Fix: all Docker install scripts now pass --os=linux --cpu=x64 (or arm…

### DIFF
--- a/scripts/docker-install-api.sh
+++ b/scripts/docker-install-api.sh
@@ -3,9 +3,16 @@ set -e
 
 . "$(dirname "$0")/linux-platform.sh"
 
-npm install --workspace=meal-diary-api --workspace=@meal-diary/shared --ignore-scripts
+npm_platform_flags="--os=${NPM_OS} --cpu=${NPM_CPU}"
 
-npm install --workspace=meal-diary-api \
+npm install ${npm_platform_flags} \
+  --workspace=meal-diary-api \
+  --workspace=@meal-diary/shared \
+  --ignore-scripts
+
+npm install ${npm_platform_flags} \
+  --workspace=meal-diary-api \
+  --ignore-scripts \
   "@esbuild/${LINUX_ESBUILD_ARCH}@0.28.1"
 
 npm rebuild bcrypt --build-from-source --workspace=meal-diary-api

--- a/scripts/docker-install-frontend.sh
+++ b/scripts/docker-install-frontend.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 set -e
 
-npm install --workspace=nuxt-app --workspace=@meal-diary/shared --ignore-scripts
+. "$(dirname "$0")/linux-platform.sh"
+
+npm install --os="${NPM_OS}" --cpu="${NPM_CPU}" \
+  --workspace=nuxt-app \
+  --workspace=@meal-diary/shared \
+  --ignore-scripts
+
 sh scripts/install-frontend-native-deps.sh

--- a/scripts/install-frontend-native-deps.sh
+++ b/scripts/install-frontend-native-deps.sh
@@ -3,16 +3,23 @@ set -e
 
 . "$(dirname "$0")/linux-platform.sh"
 
+npm_platform_flags="--os=${NPM_OS} --cpu=${NPM_CPU}"
+
 oxc_version="0.132.0"
 lightningcss_version="1.32.0"
 oxide_version="4.3.0"
 rollup_version="4.60.3"
 rolldown_version="1.0.3"
 
-# Lockfile is often generated on macOS; re-resolve Linux optional deps before lifecycle scripts.
-npm install --workspace=nuxt-app --ignore-scripts --include=optional
+# Lockfile is often generated on macOS; install for the actual Linux build CPU.
+npm install ${npm_platform_flags} \
+  --workspace=nuxt-app \
+  --ignore-scripts \
+  --include=optional
 
-npm install --workspace=nuxt-app --ignore-scripts \
+npm install ${npm_platform_flags} \
+  --workspace=nuxt-app \
+  --ignore-scripts \
   "@esbuild/${LINUX_ESBUILD_ARCH}@0.25.12" \
   "@esbuild/${LINUX_ESBUILD_ARCH}@0.28.1" \
   "@oxc-parser/binding-${oxc_platform}@${oxc_version}" \

--- a/scripts/linux-platform.sh
+++ b/scripts/linux-platform.sh
@@ -2,11 +2,13 @@
 # Shared Linux platform detection for Docker/Railway installs.
 case "$(uname -m)" in
   aarch64 | arm64)
+    NPM_CPU="arm64"
     LINUX_ESBUILD_ARCH="linux-arm64"
     arch_suffix="arm64-gnu"
     oxc_platform="linux-arm64-gnu"
     ;;
   x86_64 | amd64)
+    NPM_CPU="x64"
     LINUX_ESBUILD_ARCH="linux-x64"
     arch_suffix="x64-gnu"
     oxc_platform="linux-x64-gnu"
@@ -17,4 +19,5 @@ case "$(uname -m)" in
     ;;
 esac
 
-export LINUX_ESBUILD_ARCH arch_suffix oxc_platform
+export NPM_OS="linux"
+export NPM_CPU LINUX_ESBUILD_ARCH arch_suffix oxc_platform


### PR DESCRIPTION
…64 when detected) so npm installs packages for the build machine, not the lockfile host.