### PR TITLE
Refactor authentication handling and improve token refresh logic

### DIFF
--- a/frontend/composables/useAuth.ts
+++ b/frontend/composables/useAuth.ts
@@ -2,6 +2,8 @@ import { ref } from 'vue';
 import { useAuthStore } from '~/stores/auth';
 import { useRouter } from 'vue-router';
 import { useApi } from '~/composables/useApi';
+import { isTokenExpired } from '~/composables/useJWT';
+import { getHttpStatusCode } from '~/utils/httpError';
 import type { ResolvedEntitlements } from '~/types/Entitlements';
 
 /**
@@ -176,6 +178,7 @@ export const useAuth = () => {
         throw new Error('No refresh token available');
       }
 
+      const refreshTokenUsed = authStore.refreshToken;
       console.log('[Token Debug] refreshTokens: calling /api/auth/refresh-token');
       
       // Use $fetch directly instead of useApi to prevent recursion
@@ -183,7 +186,7 @@ export const useAuth = () => {
       const response = await $fetch('/api/auth/refresh-token', {
         method: 'POST',
         body: {
-          refreshToken: authStore.refreshToken
+          refreshToken: refreshTokenUsed
         }
       }) as TokenResponse;
 
@@ -199,6 +202,19 @@ export const useAuth = () => {
       
       return response;
     } catch (err: any) {
+      const statusCode = getHttpStatusCode(err);
+
+      // Another caller (parallel tab, SSE, or a prior in-flight request) may have
+      // already rotated the refresh token — don't treat that as session expiry.
+      if (statusCode === 403 && authStore.accessToken && !isTokenExpired(authStore.accessToken, 0)) {
+        console.warn('[Token Debug] refreshTokens: 403 but access token still valid — keeping session');
+        return {
+          accessToken: authStore.accessToken,
+          refreshToken: authStore.refreshToken!,
+          user: authStore.user ?? undefined,
+        };
+      }
+
       console.error('[Token Debug] refreshTokens: failed', {
         statusCode: err?.statusCode ?? err?.status ?? err?.data?.statusCode,
         message: err?.data?.message ?? err?.message,

--- a/frontend/server/utils/auth.ts
+++ b/frontend/server/utils/auth.ts
@@ -1,41 +1,19 @@
 import { H3Event } from 'h3';
-import type { TokenResponse } from '~/types/Auth';
 import type { ApiResponse } from '~/types/Api';
-import { isTokenExpired } from './jwt';
-import { getApiBaseUrl } from '~/server/utils/apiBaseUrl';
-import {
-  toApiHttpError,
-  getHttpStatusCode,
-  AUTH_RETRY_MESSAGE,
-} from '~/utils/httpError';
+import { apiFetch } from '~/server/utils/fetch';
 
-async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
-  const refreshResponse = await fetch(`${getApiBaseUrl()}/auth/refresh-token`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ refreshToken }),
-  });
-
-  if (!refreshResponse.ok) {
-    const errorData = await refreshResponse.json().catch(() => ({ message: 'Failed to refresh token' }));
-    throw {
-      statusCode: refreshResponse.status,
-      message: errorData.message || 'Failed to refresh token',
-    };
-  }
-
-  return refreshResponse.json() as Promise<TokenResponse>;
-}
-
+/**
+ * Proxy an authenticated request to the API, forwarding bearer and refresh
+ * headers from the client. Token refresh is handled exclusively on the client
+ * (useApi / initializeAuth) to avoid rotation races where the server refreshes
+ * with a stale refresh token and the client never receives the new pair.
+ */
 export async function authenticatedFetch<T>(
   event: H3Event,
   url: string,
   options: RequestInit = {}
 ): Promise<ApiResponse<T>> {
   const authHeader = getHeader(event, 'authorization');
-  const refreshToken = getHeader(event, 'x-refresh-token');
 
   if (!authHeader) {
     throw createError({
@@ -44,106 +22,7 @@ export async function authenticatedFetch<T>(
     });
   }
 
-  let accessToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : authHeader;
+  const data = await apiFetch<T>(url, options, event);
 
-  // Track new tokens produced by any server-side refresh so we can always
-  // propagate them back to the client regardless of which code path ran.
-  let rotatedTokens: TokenResponse | null = null;
-
-  // Pre-request refresh: if the access token is close to expiry and we have a
-  // refresh token, rotate now before the upstream call.
-  if (refreshToken) {
-    const expired = isTokenExpired(accessToken, 30);
-    console.log(`[Token Debug] authenticatedFetch: url=${url} accessExpired(30s)=${expired} hasRefreshToken=${!!refreshToken}`);
-
-    if (expired) {
-      console.log('[Token Debug] authenticatedFetch: pre-request refresh starting');
-      try {
-        const tokenData = await refreshAccessToken(refreshToken);
-        accessToken = tokenData.accessToken;
-        rotatedTokens = tokenData;
-        console.log('[Token Debug] authenticatedFetch: pre-request refresh succeeded');
-      } catch (err: unknown) {
-        const { statusCode, message } = toApiHttpError(err);
-        const actuallyExpired = isTokenExpired(accessToken, 0);
-        console.warn('[Token Debug] authenticatedFetch: pre-request refresh failed', {
-          statusCode,
-          message,
-          actuallyExpired,
-        });
-
-        if (!actuallyExpired && statusCode === 403) {
-          // Client already rotated the refresh token; the access token in the
-          // request is still valid — proceed with it.
-          console.log('[Token Debug] authenticatedFetch: 403 but access still valid, proceeding');
-        } else if (actuallyExpired && statusCode === 403) {
-          // Access is genuinely expired but refresh token was already rotated.
-          // Signal the client to retry with its latest stored tokens.
-          console.warn('[Token Debug] authenticatedFetch: 403 + access expired → sending AUTH_RETRY_MESSAGE 401');
-          throw createError({
-            statusCode: 401,
-            message: `${AUTH_RETRY_MESSAGE}. Please retry with new tokens.`,
-          });
-        } else {
-          throw createError({ statusCode: statusCode || 401, message });
-        }
-      }
-    }
-  }
-
-  const makeRequest = async (token: string) => {
-    const response = await apiFetch<T>(url, {
-      ...options,
-      headers: {
-        'Authorization': `Bearer ${token}`,
-        ...options.headers,
-      },
-    }, event);
-    return { data: response, headers: {} };
-  };
-
-  try {
-    const result = await makeRequest(accessToken);
-    return {
-      ...result,
-      headers: rotatedTokens
-        ? {
-            'x-new-access-token': rotatedTokens.accessToken,
-            'x-new-refresh-token': rotatedTokens.refreshToken,
-          }
-        : {},
-    };
-  } catch (err: unknown) {
-    const status = getHttpStatusCode(err);
-    console.warn('[Token Debug] authenticatedFetch: makeRequest failed', {
-      url,
-      statusCode: status,
-      message: toApiHttpError(err).message,
-    });
-
-    // Fallback refresh: access token expired between our check and the actual
-    // request (race condition), or wasn't caught by the buffer above.
-    if (status === 401 && refreshToken) {
-      console.log('[Token Debug] authenticatedFetch: fallback refresh starting');
-      try {
-        const data = await refreshAccessToken(refreshToken);
-        rotatedTokens = data;
-        console.log('[Token Debug] authenticatedFetch: fallback refresh succeeded');
-        const result = await makeRequest(data.accessToken);
-        return {
-          ...result,
-          headers: {
-            'x-new-access-token': data.accessToken,
-            'x-new-refresh-token': data.refreshToken,
-          },
-        };
-      } catch (refreshErr: unknown) {
-        const { statusCode, message } = toApiHttpError(refreshErr);
-        console.error('[Token Debug] authenticatedFetch: fallback refresh failed', { statusCode, message });
-        throw createError({ statusCode: statusCode || 401, message });
-      }
-    }
-
-    throw err;
-  }
+  return { data, headers: {} };
 }

--- a/frontend/stores/auth.ts
+++ b/frontend/stores/auth.ts
@@ -216,8 +216,13 @@ export const useAuthStore = defineStore('auth', () => {
               console.log('[Token Debug] initializeAuth: proactive refresh succeeded');
             } catch (err: unknown) {
               if (isSessionExpiredError(err)) {
-                console.error('[Token Debug] initializeAuth: session expired, clearing auth');
-                await clearAuth();
+                // Refresh can 403 when another request already rotated tokens.
+                if (accessToken.value && !isTokenExpired(accessToken.value, 0)) {
+                  console.warn('[Token Debug] initializeAuth: refresh 403 but access still valid, keeping session');
+                } else {
+                  console.error('[Token Debug] initializeAuth: session expired, clearing auth');
+                  await clearAuth();
+                }
               } else {
                 // Network/transient failure — keep the session; useApi will retry on next request.
                 console.warn('[Token Debug] initializeAuth: proactive refresh failed (non-fatal)', err);

--- a/frontend/utils/tokenRefresh.ts
+++ b/frontend/utils/tokenRefresh.ts
@@ -2,13 +2,20 @@
  * Serialises concurrent token refresh attempts across useApi, initializeAuth,
  * and the app-resume handler. Prevents rotation races on mobile where multiple
  * callers can fire at once when the app returns from background.
+ *
+ * If a refresh is already in flight, callers wait for it. When the in-flight
+ * refresh fails, the next caller retries instead of silently skipping refresh.
  */
 let refreshPromise: Promise<void> | null = null;
 
 export async function runWithTokenRefreshLock(refreshFn: () => Promise<void>): Promise<void> {
   if (refreshPromise) {
-    await refreshPromise;
-    return;
+    try {
+      await refreshPromise;
+      return;
+    } catch {
+      // Prior refresh failed — fall through so this caller can retry.
+    }
   }
 
   refreshPromise = (async () => {


### PR DESCRIPTION
- Updated `useAuth` to handle token refresh more robustly, ensuring valid access tokens are retained during refresh failures.
- Simplified `authenticatedFetch` by removing redundant token refresh logic and directly utilizing `apiFetch`.
- Enhanced `useAuthStore` to manage session state more effectively when refresh attempts fail.
- Introduced a locking mechanism in `runWithTokenRefreshLock` to prevent concurrent refresh attempts from causing race conditions.