### PR TITLE
Add recipe URL import across API, Nuxt, and Expo.

### DIFF
--- a/api/controllers/__tests__/recipe.controller.unit.test.ts
+++ b/api/controllers/__tests__/recipe.controller.unit.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+
+vi.mock('../../services/recipeImport.service.ts', () => ({
+  importRecipeFromUrl: vi.fn(),
+}));
+
+vi.mock('../../services/entitlements.service.ts', async () => {
+  const actual = await vi.importActual<typeof import('../../services/entitlements.service.ts')>(
+    '../../services/entitlements.service.ts'
+  );
+
+  return {
+    ...actual,
+    assertCanCreateRecipe: vi.fn(),
+  };
+});
+
+import * as EntitlementsService from '../../services/entitlements.service.ts';
+import * as recipeImportService from '../../services/recipeImport.service.ts';
+import { importRecipeFromUrl } from '../recipe/recipe.controller.ts';
+import {
+  InvalidRecipeImportUrlError,
+  RecipeImportParseError,
+} from '../../services/recipeImportParser.service.ts';
+
+const mockRequest = (body: Record<string, unknown>, familyGroupId = 10, userId = 5) =>
+  ({
+    body,
+    user: {
+      dataValues: {
+        id: userId,
+        family_group_id: familyGroupId,
+      },
+    },
+  }) as unknown as Request;
+
+const mockResponse = () =>
+  ({
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  }) as unknown as Response;
+
+describe('recipe.controller importRecipeFromUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 201 with the created recipe', async () => {
+    vi.mocked(EntitlementsService.assertCanCreateRecipe).mockResolvedValue({} as never);
+    vi.mocked(recipeImportService.importRecipeFromUrl).mockResolvedValue({
+      id: 99,
+      name: 'Imported pasta',
+    } as never);
+
+    const req = mockRequest({
+      family_group_id: 10,
+      url: 'https://example.com/recipe',
+    });
+    const res = mockResponse();
+
+    await importRecipeFromUrl(req, res);
+
+    expect(EntitlementsService.assertCanCreateRecipe).toHaveBeenCalledWith(10, 5);
+    expect(recipeImportService.importRecipeFromUrl).toHaveBeenCalledWith({
+      family_group_id: 10,
+      created_by: 5,
+      url: 'https://example.com/recipe',
+    });
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      id: 99,
+      name: 'Imported pasta',
+    });
+  });
+
+  it('returns 400 when family group id or url is missing', async () => {
+    const req = mockRequest({ family_group_id: 10 });
+    const res = mockResponse();
+
+    await importRecipeFromUrl(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Family group ID and URL are required',
+    });
+    expect(recipeImportService.importRecipeFromUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the user is not in the target family group', async () => {
+    const req = mockRequest({
+      family_group_id: 11,
+      url: 'https://example.com/recipe',
+    });
+    const res = mockResponse();
+
+    await importRecipeFromUrl(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Forbidden' });
+    expect(recipeImportService.importRecipeFromUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns entitlement errors as 403 responses', async () => {
+    const error = new EntitlementsService.EntitlementRequiredError('recipes', 'premium');
+    vi.mocked(EntitlementsService.assertCanCreateRecipe).mockRejectedValue(error);
+
+    const req = mockRequest({
+      family_group_id: 10,
+      url: 'https://example.com/recipe',
+    });
+    const res = mockResponse();
+
+    await importRecipeFromUrl(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      code: error.code,
+      feature: 'recipes',
+      plan: 'premium',
+      upgradeUrl: '/plans',
+    });
+  });
+
+  it('returns 400 for invalid recipe urls', async () => {
+    vi.mocked(EntitlementsService.assertCanCreateRecipe).mockResolvedValue({} as never);
+    vi.mocked(recipeImportService.importRecipeFromUrl).mockRejectedValue(
+      new InvalidRecipeImportUrlError()
+    );
+
+    const req = mockRequest({
+      family_group_id: 10,
+      url: 'not-a-url',
+    });
+    const res = mockResponse();
+
+    await importRecipeFromUrl(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid recipe URL' });
+  });
+
+  it('returns 422 when the page cannot be parsed into a recipe', async () => {
+    vi.mocked(EntitlementsService.assertCanCreateRecipe).mockResolvedValue({} as never);
+    vi.mocked(recipeImportService.importRecipeFromUrl).mockRejectedValue(
+      new RecipeImportParseError('Recipe schema not found on page')
+    );
+
+    const req = mockRequest({
+      family_group_id: 10,
+      url: 'https://example.com/recipe',
+    });
+    const res = mockResponse();
+
+    await importRecipeFromUrl(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Recipe schema not found on page',
+    });
+  });
+
+  it('returns 500 on unexpected failures', async () => {
+    vi.mocked(EntitlementsService.assertCanCreateRecipe).mockResolvedValue({} as never);
+    vi.mocked(recipeImportService.importRecipeFromUrl).mockRejectedValue(new Error('boom'));
+
+    const req = mockRequest({
+      family_group_id: 10,
+      url: 'https://example.com/recipe',
+    });
+    const res = mockResponse();
+
+    await importRecipeFromUrl(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Failed to import recipe from URL',
+    });
+  });
+});

--- a/api/controllers/recipe/recipe.controller.ts
+++ b/api/controllers/recipe/recipe.controller.ts
@@ -1,8 +1,13 @@
 import type { Request, Response } from 'express';
 import { User } from '../../db/models/associations.ts';
 import * as recipeService from '../../services/recipe.service.ts';
+import * as recipeImportService from '../../services/recipeImport.service.ts';
 import * as EntitlementsService from '../../services/entitlements.service.ts';
 import { handleEntitlementError } from '../../middleware/entitlement.middleware.ts';
+import {
+  InvalidRecipeImportUrlError,
+  RecipeImportParseError,
+} from '../../services/recipeImportParser.service.ts';
 
 /**
  * Get all recipes for a family group
@@ -98,6 +103,55 @@ export const createRecipe = async (req: Request, res: Response) => {
   } catch (error) {
     console.error('Error creating recipe:', error);
     return res.status(500).json({ message: 'Failed to create recipe' });
+  }
+};
+
+/**
+ * Import a recipe from a URL
+ */
+export const importRecipeFromUrl = async (req: Request, res: Response) => {
+  try {
+    const { family_group_id, url } = req.body;
+    const user = req.user as User;
+
+    if (!family_group_id || !url) {
+      return res.status(400).json({ message: 'Family group ID and URL are required' });
+    }
+
+    if (user.dataValues.family_group_id !== parseInt(family_group_id, 10)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    try {
+      await EntitlementsService.assertCanCreateRecipe(
+        parseInt(family_group_id, 10),
+        user.dataValues.id
+      );
+    } catch (error) {
+      if (handleEntitlementError(error, res)) {
+        return;
+      }
+      throw error;
+    }
+
+    const recipe = await recipeImportService.importRecipeFromUrl({
+      family_group_id: parseInt(family_group_id, 10),
+      created_by: user.dataValues.id,
+      url,
+    });
+
+    return res.status(201).json(recipe);
+  } catch (error) {
+    if (error instanceof InvalidRecipeImportUrlError) {
+      return res.status(400).json({ message: error.message });
+    }
+
+    if (error instanceof RecipeImportParseError) {
+      return res.status(422).json({ message: error.message });
+    }
+
+    console.error('Error importing recipe from URL:', error);
+    return res.status(500).json({ message: 'Failed to import recipe from URL' });
   }
 };
 

--- a/api/routes/recipes.routes.ts
+++ b/api/routes/recipes.routes.ts
@@ -191,6 +191,14 @@ router.post('/', authenticateToken, async (req, res, next) => {
   }
 });
 
+router.post('/import-from-url', authenticateToken, async (req, res, next) => {
+  try {
+    await recipeController.importRecipeFromUrl(req, res);
+  } catch (error) {
+    next(error);
+  }
+});
+
 /**
  * @openapi
  * /recipes/{id}:

--- a/api/services/__tests__/recipeImport.service.unit.test.ts
+++ b/api/services/__tests__/recipeImport.service.unit.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../recipe.service.ts', () => ({
+  createRecipe: vi.fn(),
+}));
+
+vi.mock('../recipeImportParser.service.ts', () => ({
+  parseRecipeFromUrl: vi.fn(),
+}));
+
+import { createRecipe } from '../recipe.service.ts';
+import { parseRecipeFromUrl } from '../recipeImportParser.service.ts';
+import { importRecipeFromUrl } from '../recipeImport.service.ts';
+
+describe('recipeImport.service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps parsed recipe data into createRecipe', async () => {
+    vi.mocked(parseRecipeFromUrl).mockResolvedValue({
+      name: 'Imported curry',
+      description: 'Weeknight dinner',
+      instructions: 'Cook.\n\nServe.',
+      portions: 4,
+      ingredients: [
+        { name: 'Onion', quantity: 1, unit: null },
+        { name: 'Curry powder', quantity: 2, unit: 'tsp' },
+      ],
+    });
+    vi.mocked(createRecipe).mockResolvedValue({ id: 42 } as never);
+
+    const result = await importRecipeFromUrl({
+      family_group_id: 7,
+      created_by: 3,
+      url: 'https://example.com/curry',
+    });
+
+    expect(parseRecipeFromUrl).toHaveBeenCalledWith('https://example.com/curry');
+    expect(createRecipe).toHaveBeenCalledWith({
+      family_group_id: 7,
+      created_by: 3,
+      name: 'Imported curry',
+      description: 'Weeknight dinner',
+      instructions: 'Cook.\n\nServe.',
+      portions: 4,
+      ingredients: [
+        { name: 'Onion', quantity: 1, unit: undefined },
+        { name: 'Curry powder', quantity: 2, unit: 'tsp' },
+      ],
+    });
+    expect(result).toEqual({ id: 42 });
+  });
+
+  it('propagates parser failures without creating a recipe', async () => {
+    vi.mocked(parseRecipeFromUrl).mockRejectedValue(new Error('parse failed'));
+
+    await expect(importRecipeFromUrl({
+      family_group_id: 7,
+      created_by: 3,
+      url: 'https://example.com/curry',
+    })).rejects.toThrow('parse failed');
+
+    expect(createRecipe).not.toHaveBeenCalled();
+  });
+});

--- a/api/services/__tests__/recipeImportParser.unit.test.ts
+++ b/api/services/__tests__/recipeImportParser.unit.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  InvalidRecipeImportUrlError,
+  parseRecipeFromHtml,
+  parseRecipeFromUrl,
+  RecipeImportParseError,
+} from '../recipeImportParser.service.ts';
+
+describe('recipeImportParser.service', () => {
+  it('maps recipe schema into the internal draft shape', () => {
+    const html = `
+      <html>
+        <head>
+          <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "Recipe",
+              "name": "Tomato Pasta",
+              "description": "Fast dinner",
+              "recipeYield": "Serves 4",
+              "recipeIngredient": ["1 onion", "2 tsp olive oil", "400 g tomatoes"],
+              "recipeInstructions": [
+                { "@type": "HowToStep", "text": "Chop the onion" },
+                { "@type": "HowToStep", "text": "Cook everything together" }
+              ]
+            }
+          </script>
+        </head>
+      </html>
+    `;
+
+    expect(parseRecipeFromHtml(html)).toEqual({
+      name: 'Tomato Pasta',
+      description: 'Fast dinner',
+      instructions: 'Chop the onion\n\nCook everything together',
+      portions: 4,
+      ingredients: [
+        { name: 'onion', quantity: 1, unit: null },
+        { name: 'olive oil', quantity: 2, unit: 'tsp' },
+        { name: 'tomatoes', quantity: 400, unit: 'g' },
+      ],
+    });
+  });
+
+  it('handles missing optional fields gracefully', () => {
+    const html = `
+      <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "Recipe",
+              "name": "Toast"
+            }
+          ]
+        }
+      </script>
+    `;
+
+    expect(parseRecipeFromHtml(html)).toEqual({
+      name: 'Toast',
+      description: undefined,
+      instructions: undefined,
+      portions: undefined,
+      ingredients: [],
+    });
+  });
+
+  it('rejects malformed urls', async () => {
+    await expect(parseRecipeFromUrl('not-a-url')).rejects.toBeInstanceOf(InvalidRecipeImportUrlError);
+  });
+
+  it('rejects pages without recipe schema', () => {
+    expect(() => parseRecipeFromHtml('<html><body>No schema here</body></html>'))
+      .toThrow(RecipeImportParseError);
+  });
+});

--- a/api/services/recipe.service.ts
+++ b/api/services/recipe.service.ts
@@ -2,14 +2,14 @@ import { Recipe, RecipeIngredient, DailyMeal } from '../db/models/associations.t
 import { Op } from 'sequelize';
 import sequelize from '../db/models/index.ts';
 
-interface IngredientInput {
+export interface IngredientInput {
   id?: number;
   name: string;
   quantity?: number;
   unit?: string;
 }
 
-interface CreateRecipeInput {
+export interface CreateRecipeInput {
   family_group_id: number;
   created_by: number;
   name: string;

--- a/api/services/recipeImport.service.ts
+++ b/api/services/recipeImport.service.ts
@@ -1,0 +1,34 @@
+import { createRecipe } from './recipe.service.ts';
+import {
+  parseRecipeFromUrl,
+  type ParsedRecipeDraft,
+} from './recipeImportParser.service.ts';
+
+interface ImportRecipeFromUrlInput {
+  family_group_id: number;
+  created_by: number;
+  url: string;
+}
+
+const mapImportedRecipeToCreatePayload = (
+  importedRecipe: ParsedRecipeDraft,
+  input: ImportRecipeFromUrlInput
+) => ({
+  family_group_id: input.family_group_id,
+  created_by: input.created_by,
+  name: importedRecipe.name,
+  description: importedRecipe.description,
+  instructions: importedRecipe.instructions,
+  portions: importedRecipe.portions,
+  ingredients: importedRecipe.ingredients.map((ingredient) => ({
+    name: ingredient.name,
+    quantity: ingredient.quantity ?? undefined,
+    unit: ingredient.unit ?? undefined,
+  })),
+});
+
+export const importRecipeFromUrl = async (input: ImportRecipeFromUrlInput) => {
+  const importedRecipe = await parseRecipeFromUrl(input.url);
+
+  return createRecipe(mapImportedRecipeToCreatePayload(importedRecipe, input));
+};

--- a/api/services/recipeImportParser.service.ts
+++ b/api/services/recipeImportParser.service.ts
@@ -1,0 +1,291 @@
+export interface ParsedRecipeIngredient {
+  name: string;
+  quantity?: number | null;
+  unit?: string | null;
+}
+
+export interface ParsedRecipeDraft {
+  name: string;
+  description?: string;
+  instructions?: string;
+  portions?: number;
+  ingredients: ParsedRecipeIngredient[];
+}
+
+export class InvalidRecipeImportUrlError extends Error {
+  constructor(message = 'Invalid recipe URL') {
+    super(message);
+    this.name = 'InvalidRecipeImportUrlError';
+  }
+}
+
+export class RecipeImportParseError extends Error {
+  constructor(message = 'Failed to parse recipe from URL') {
+    super(message);
+    this.name = 'RecipeImportParseError';
+  }
+}
+
+const commonUnits = new Set([
+  'tsp',
+  'teaspoon',
+  'teaspoons',
+  'tbsp',
+  'tablespoon',
+  'tablespoons',
+  'cup',
+  'cups',
+  'g',
+  'kg',
+  'ml',
+  'l',
+  'oz',
+  'lb',
+  'lbs',
+  'clove',
+  'cloves',
+  'slice',
+  'slices',
+  'can',
+  'cans',
+  'tin',
+  'tins',
+  'pinch',
+  'pinches',
+  'sprig',
+  'sprigs',
+  'bunch',
+  'bunches',
+  'packet',
+  'packets',
+]);
+
+const jsonLdScriptPattern = /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+
+const sanitizeWhitespace = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+const normalizeInstructionStep = (value: unknown): string[] => {
+  if (typeof value === 'string') {
+    const normalized = sanitizeWhitespace(value);
+    return normalized ? [normalized] : [];
+  }
+
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+
+  const item = value as Record<string, unknown>;
+
+  if (typeof item.text === 'string') {
+    const normalized = sanitizeWhitespace(item.text);
+    return normalized ? [normalized] : [];
+  }
+
+  if (typeof item.name === 'string') {
+    const normalized = sanitizeWhitespace(item.name);
+    return normalized ? [normalized] : [];
+  }
+
+  if (Array.isArray(item.itemListElement)) {
+    return item.itemListElement.flatMap(normalizeInstructionStep);
+  }
+
+  return [];
+};
+
+const parseFraction = (value: string): number | null => {
+  if (!value.includes('/')) {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  const [numerator, denominator] = value.split('/');
+  const parsedNumerator = Number.parseFloat(numerator);
+  const parsedDenominator = Number.parseFloat(denominator);
+
+  if (!Number.isFinite(parsedNumerator) || !Number.isFinite(parsedDenominator) || parsedDenominator === 0) {
+    return null;
+  }
+
+  return parsedNumerator / parsedDenominator;
+};
+
+const parseQuantityToken = (value: string): number | null => {
+  const parts = value.trim().split(/\s+/);
+  const parsedParts = parts.map(parseFraction);
+
+  if (parsedParts.some((part) => part == null)) {
+    return null;
+  }
+
+  return parsedParts.reduce<number>((sum, part) => sum + (part ?? 0), 0);
+};
+
+const parseIngredientText = (value: string): ParsedRecipeIngredient => {
+  const trimmed = sanitizeWhitespace(value);
+  const parts = trimmed.split(' ');
+  const quantityParts: string[] = [];
+
+  while (parts.length > 0) {
+    const candidate = [...quantityParts, parts[0]].join(' ').trim();
+    const parsed = parseQuantityToken(candidate);
+
+    if (parsed == null) {
+      break;
+    }
+
+    quantityParts.push(parts.shift() as string);
+  }
+
+  const quantity = quantityParts.length > 0 ? parseQuantityToken(quantityParts.join(' ')) : null;
+  const nextPart = parts[0]?.toLowerCase().replace(/[.,]$/, '');
+  const hasUnit = nextPart ? commonUnits.has(nextPart) : false;
+  const unit = hasUnit ? sanitizeWhitespace(parts.shift() as string) : null;
+  const name = sanitizeWhitespace(parts.join(' ')) || trimmed;
+
+  return {
+    name,
+    quantity,
+    unit,
+  };
+};
+
+const parsePortions = (value: unknown): number | undefined => {
+  const candidate = Array.isArray(value) ? value[0] : value;
+
+  if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+    return candidate;
+  }
+
+  if (typeof candidate !== 'string') {
+    return undefined;
+  }
+
+  const match = candidate.match(/\d+/);
+  if (!match) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(match[0], 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const extractJsonLdNodes = (html: string): unknown[] => {
+  const nodes: unknown[] = [];
+
+  for (const match of html.matchAll(jsonLdScriptPattern)) {
+    const rawJson = match[1]?.trim();
+
+    if (!rawJson) {
+      continue;
+    }
+
+    try {
+      nodes.push(JSON.parse(rawJson));
+    } catch {
+      continue;
+    }
+  }
+
+  return nodes;
+};
+
+const flattenJsonLdNodes = (node: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(node)) {
+    return node.flatMap(flattenJsonLdNodes);
+  }
+
+  if (!node || typeof node !== 'object') {
+    return [];
+  }
+
+  const record = node as Record<string, unknown>;
+  const graphNodes = Array.isArray(record['@graph']) ? record['@graph'].flatMap(flattenJsonLdNodes) : [];
+
+  return [record, ...graphNodes];
+};
+
+const isRecipeNode = (node: Record<string, unknown>): boolean => {
+  const nodeType = node['@type'];
+
+  if (typeof nodeType === 'string') {
+    return nodeType.toLowerCase() === 'recipe';
+  }
+
+  if (Array.isArray(nodeType)) {
+    return nodeType.some((value) => typeof value === 'string' && value.toLowerCase() === 'recipe');
+  }
+
+  return false;
+};
+
+export const normalizeRecipeImportUrl = (value: string): string => {
+  try {
+    const url = new URL(value.trim());
+
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      throw new InvalidRecipeImportUrlError();
+    }
+
+    return url.toString();
+  } catch {
+    throw new InvalidRecipeImportUrlError();
+  }
+};
+
+export const parseRecipeFromHtml = (html: string): ParsedRecipeDraft => {
+  const recipeNode = extractJsonLdNodes(html)
+    .flatMap(flattenJsonLdNodes)
+    .find(isRecipeNode);
+
+  if (!recipeNode) {
+    throw new RecipeImportParseError('Recipe schema not found on page');
+  }
+
+  const name = typeof recipeNode.name === 'string' ? sanitizeWhitespace(recipeNode.name) : '';
+  if (!name) {
+    throw new RecipeImportParseError('Recipe name not found on page');
+  }
+
+  const description = typeof recipeNode.description === 'string'
+    ? sanitizeWhitespace(recipeNode.description)
+    : undefined;
+
+  const instructionsSource = recipeNode.recipeInstructions;
+  const instructions = Array.isArray(instructionsSource)
+    ? instructionsSource.flatMap(normalizeInstructionStep).join('\n\n')
+    : normalizeInstructionStep(instructionsSource).join('\n\n');
+
+  const ingredientSource = Array.isArray(recipeNode.recipeIngredient) ? recipeNode.recipeIngredient : [];
+  const ingredients = ingredientSource
+    .filter((ingredient): ingredient is string => typeof ingredient === 'string')
+    .map(parseIngredientText);
+
+  return {
+    name,
+    description: description || undefined,
+    instructions: instructions || undefined,
+    portions: parsePortions(recipeNode.recipeYield),
+    ingredients,
+  };
+};
+
+export const parseRecipeFromUrl = async (
+  value: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<ParsedRecipeDraft> => {
+  const normalizedUrl = normalizeRecipeImportUrl(value);
+  const response = await fetchImpl(normalizedUrl, {
+    headers: {
+      'User-Agent': 'MealDiaryRecipeImporter/1.0',
+      'Accept': 'text/html,application/xhtml+xml',
+    },
+  });
+
+  if (!response.ok) {
+    throw new RecipeImportParseError(`Failed to fetch recipe page (${response.status})`);
+  }
+
+  const html = await response.text();
+  return parseRecipeFromHtml(html);
+};

--- a/apps/mobile/app/(tabs)/recipes/create.tsx
+++ b/apps/mobile/app/(tabs)/recipes/create.tsx
@@ -1,6 +1,6 @@
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { useRouter, type Href } from 'expo-router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   KeyboardAvoidingView,
@@ -8,11 +8,14 @@ import {
   Platform,
   Pressable,
   ScrollView,
+  TextInput,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { RecipeForm, type RecipeFormValues } from '@/components/recipe/RecipeForm';
+import { DialogModal, DialogPanel } from '@/components/ui/DialogModal';
 import { Box } from '@/components/ui/box';
+import { Button, ButtonSpinner, ButtonText } from '@/components/ui/button';
 import { Heading } from '@/components/ui/heading';
 import { Text } from '@/components/ui/text';
 import { env } from '@/constants/env';
@@ -20,8 +23,8 @@ import { getEntitlementFeatureFromError } from '@/lib/entitlements/entitlementEr
 import { usePaywallStore } from '@/lib/entitlements/paywallStore';
 import { useRecipeEntitlements } from '@/lib/entitlements/useRecipeEntitlements';
 import { useCurrentUser, useEntitlements } from '@/lib/queries/profile';
-import { useCreateRecipe } from '@/lib/queries/recipes';
-import type { CreateRecipePayload } from '@/types/recipe';
+import { useCreateRecipe, useImportRecipeFromUrl } from '@/lib/queries/recipes';
+import type { CreateRecipePayload, ImportRecipeFromUrlPayload } from '@/types/recipe';
 
 export default function CreateRecipeScreen() {
   const { t } = useTranslation();
@@ -32,11 +35,48 @@ export default function CreateRecipeScreen() {
   const entitlementsQuery = useEntitlements(familyGroupId);
   const recipeEntitlements = useRecipeEntitlements(entitlementsQuery.data);
   const createRecipeMutation = useCreateRecipe();
+  const importRecipeMutation = useImportRecipeFromUrl();
   const openPaywall = usePaywallStore((state) => state.openPaywall);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [creationMode, setCreationMode] = useState<'manual' | 'import' | null>(null);
+  const [creationMethodVisible, setCreationMethodVisible] = useState(true);
+  const [importUrl, setImportUrl] = useState('');
+  const [importProgressStep, setImportProgressStep] = useState(0);
+
+  useEffect(() => {
+    if (!importRecipeMutation.isPending) {
+      setImportProgressStep(0);
+      return;
+    }
+
+    const fetchingTimeout = setTimeout(() => setImportProgressStep(1), 900);
+    const creatingTimeout = setTimeout(() => setImportProgressStep(2), 1800);
+
+    return () => {
+      clearTimeout(fetchingTimeout);
+      clearTimeout(creatingTimeout);
+    };
+  }, [importRecipeMutation.isPending]);
 
   const handleOpenPlans = () => {
     void Linking.openURL(`${env.webUrl}/plans`);
+  };
+
+  const handleCloseMethodDialog = () => {
+    if (creationMode) {
+      setCreationMethodVisible(false);
+      return;
+    }
+
+    router.back();
+  };
+
+  const handleSelectCreationMode = (mode: 'manual' | 'import') => {
+    setCreationMode(mode);
+    setCreationMethodVisible(false);
+    setSubmitError(null);
+    setImportError(null);
   };
 
   const handleCreate = async (formData: RecipeFormValues) => {
@@ -68,6 +108,44 @@ export default function CreateRecipeScreen() {
       setSubmitError(t('recipeForm.createFailed'));
     }
   };
+
+  const handleImportRecipe = async () => {
+    if (!familyGroupId || !importUrl.trim()) {
+      return;
+    }
+
+    if (!recipeEntitlements.canCreateRecipe) {
+      openPaywall('recipes');
+      return;
+    }
+
+    setImportError(null);
+
+    try {
+      const recipe = await importRecipeMutation.mutateAsync({
+        familyGroupId,
+        payload: { url: importUrl.trim() } as ImportRecipeFromUrlPayload,
+      });
+      void entitlementsQuery.refetch();
+      router.replace(`/(tabs)/recipes/${recipe.id}/edit` as Href);
+    } catch (error) {
+      const entitlementFeature = getEntitlementFeatureFromError(error);
+      if (entitlementFeature) {
+        openPaywall(entitlementFeature);
+        return;
+      }
+
+      setImportError(error instanceof Error ? error.message : t('recipeImport.genericError'));
+    }
+  };
+
+  const importProgressMessages = [
+    t('recipeImport.progress.validating'),
+    t('recipeImport.progress.fetching'),
+    t('recipeImport.progress.creating'),
+  ];
+  const importInputClassName =
+    'rounded-lg border border-white/10 bg-surface px-4 py-3 text-base text-ice';
 
   return (
     <Box className="flex-1 bg-base" style={{ paddingTop: insets.top }}>
@@ -116,21 +194,135 @@ export default function CreateRecipeScreen() {
             </Box>
           ) : (
             <>
-              {submitError ? (
-                <Box className="mb-4 rounded-lg bg-red-500/15 px-4 py-3">
-                  <Text className="text-sm text-red-400">{submitError}</Text>
+              {creationMode ? (
+                <Box className="mb-4">
+                  <Button variant="outline" size="sm" onPress={() => setCreationMethodVisible(true)}>
+                    <ButtonText>{t('recipeImport.changeMethod')}</ButtonText>
+                  </Button>
                 </Box>
               ) : null}
-              <RecipeForm
-                submitLabel={t('recipeForm.createRecipe')}
-                isLoading={createRecipeMutation.isPending}
-                onSubmit={handleCreate}
-                onCancel={() => router.back()}
-              />
+
+              {creationMode === 'import' ? (
+                <Box className="rounded-2xl border border-white/10 bg-surface px-4 py-4">
+                  <Heading className="text-ice" size="md">
+                    {t('recipeImport.title')}
+                  </Heading>
+                  <Text className="mt-2 text-sm text-ice/70">
+                    {t('recipeImport.description')}
+                  </Text>
+
+                  <Text className="mb-2 mt-4 text-sm font-semibold text-ice">
+                    {t('recipeImport.urlLabel')}
+                  </Text>
+                  <TextInput
+                    className={importInputClassName}
+                    placeholder={t('recipeImport.urlPlaceholder')}
+                    placeholderTextColor="rgba(241, 245, 249, 0.4)"
+                    value={importUrl}
+                    onChangeText={setImportUrl}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    keyboardType="url"
+                    editable={!importRecipeMutation.isPending}
+                    testID="recipe-import-url-input"
+                  />
+
+                  {importError ? (
+                    <Box className="mt-4 rounded-lg bg-red-500/15 px-4 py-3" testID="recipe-import-error">
+                      <Text className="text-sm text-red-400">{importError}</Text>
+                    </Box>
+                  ) : null}
+
+                  {importRecipeMutation.isPending ? (
+                    <Box
+                      className="mt-4 rounded-lg bg-primary/15 px-4 py-3"
+                      testID="recipe-import-loading"
+                    >
+                      <Text className="text-sm font-semibold text-ice">
+                        {t('recipeImport.loadingTitle')}
+                      </Text>
+                      <Text className="mt-1 text-sm text-ice/80">
+                        {importProgressMessages[importProgressStep]}
+                      </Text>
+                    </Box>
+                  ) : null}
+
+                  <Box className="mt-4 flex-row justify-end gap-2">
+                    <Button
+                      variant="ghost"
+                      onPress={() => router.back()}
+                      disabled={importRecipeMutation.isPending}
+                    >
+                      <ButtonText>{t('common.cancel')}</ButtonText>
+                    </Button>
+                    <Button
+                      className="bg-primary"
+                      onPress={handleImportRecipe}
+                      disabled={!importUrl.trim() || importRecipeMutation.isPending}
+                      testID="recipe-import-submit-button"
+                    >
+                      {importRecipeMutation.isPending ? <ButtonSpinner color="#F1F5F9" /> : null}
+                      <ButtonText className="text-ice">{t('recipeImport.submit')}</ButtonText>
+                    </Button>
+                  </Box>
+                </Box>
+              ) : creationMode === 'manual' ? (
+                <>
+                  {submitError ? (
+                    <Box className="mb-4 rounded-lg bg-red-500/15 px-4 py-3">
+                      <Text className="text-sm text-red-400">{submitError}</Text>
+                    </Box>
+                  ) : null}
+                  <RecipeForm
+                    submitLabel={t('recipeForm.createRecipe')}
+                    isLoading={createRecipeMutation.isPending}
+                    onSubmit={handleCreate}
+                    onCancel={() => router.back()}
+                  />
+                </>
+              ) : null}
             </>
           )}
         </ScrollView>
       </KeyboardAvoidingView>
+
+      <DialogModal visible={creationMethodVisible} onClose={handleCloseMethodDialog}>
+        <DialogPanel>
+          <Heading size="lg" className="mb-3 text-ice">
+            {t('recipeImport.chooseMethodTitle')}
+          </Heading>
+          <Text className="mb-6 text-ice/80">{t('recipeImport.chooseMethodDescription')}</Text>
+          <Box className="gap-3">
+            <Pressable
+              accessibilityRole="button"
+              className="rounded-xl border border-white/10 bg-base px-4 py-4"
+              onPress={() => handleSelectCreationMode('manual')}
+              testID="recipe-create-method-manual"
+            >
+              <Text className="font-semibold text-ice">{t('recipeImport.manualOptionTitle')}</Text>
+              <Text className="mt-1 text-sm text-ice/70">
+                {t('recipeImport.manualOptionDescription')}
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              className="rounded-xl border border-white/10 bg-base px-4 py-4"
+              onPress={() => handleSelectCreationMode('import')}
+              testID="recipe-create-method-import"
+            >
+              <Text className="font-semibold text-ice">{t('recipeImport.importOptionTitle')}</Text>
+              <Text className="mt-1 text-sm text-ice/70">
+                {t('recipeImport.importOptionDescription')}
+              </Text>
+            </Pressable>
+          </Box>
+          <Box className="mt-6 flex-row justify-end">
+            <Button variant="ghost" onPress={handleCloseMethodDialog}>
+              <ButtonText>{t('common.cancel')}</ButtonText>
+            </Button>
+          </Box>
+        </DialogPanel>
+      </DialogModal>
     </Box>
   );
 }

--- a/apps/mobile/lib/i18n/index.ts
+++ b/apps/mobile/lib/i18n/index.ts
@@ -122,6 +122,27 @@ const resources = {
         updateFailed: 'Failed to update recipe',
         deleteFailed: 'Failed to delete recipe',
       },
+      recipeImport: {
+        chooseMethodTitle: 'How would you like to add this recipe?',
+        chooseMethodDescription: 'Create it by hand or import it from a recipe website.',
+        manualOptionTitle: 'Create manually',
+        manualOptionDescription: 'Start with an empty recipe form.',
+        importOptionTitle: 'Import from URL',
+        importOptionDescription: "Paste a recipe link and we'll pull in what we can.",
+        changeMethod: 'Change method',
+        title: 'Import recipe from URL',
+        description: "Paste a link to a recipe page and we'll create a recipe for your family.",
+        urlLabel: 'Recipe URL',
+        urlPlaceholder: 'https://example.com/your-recipe',
+        submit: 'Import Recipe',
+        loadingTitle: 'Importing recipe...',
+        genericError: 'Failed to import recipe',
+        progress: {
+          validating: 'Validating the link...',
+          fetching: 'Fetching the recipe page...',
+          creating: 'Creating your recipe...',
+        },
+      },
       paywall: {
         close: 'Close',
         family_members: {

--- a/apps/mobile/lib/queries/recipes.ts
+++ b/apps/mobile/lib/queries/recipes.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api/client';
 import type {
   CreateRecipePayload,
+  ImportRecipeFromUrlPayload,
   Recipe,
   UpdateRecipePayload,
 } from '@/types/recipe';
@@ -40,6 +41,19 @@ export async function createRecipe(
     body: {
       family_group_id: familyGroupId,
       ...payload,
+    },
+  });
+}
+
+export async function importRecipeFromUrl(
+  familyGroupId: number,
+  payload: ImportRecipeFromUrlPayload
+): Promise<Recipe> {
+  return apiFetch<Recipe>('/recipes/import-from-url', {
+    method: 'POST',
+    body: {
+      family_group_id: familyGroupId,
+      url: payload.url,
     },
   });
 }
@@ -105,6 +119,24 @@ export function useCreateRecipe() {
       familyGroupId: number;
       payload: CreateRecipePayload;
     }) => createRecipe(familyGroupId, payload),
+    onSuccess: (recipe, { familyGroupId }) => {
+      queryClient.setQueryData(recipeKeys.detail(recipe.id), recipe);
+      invalidateRecipeQueries(queryClient, familyGroupId);
+    },
+  });
+}
+
+export function useImportRecipeFromUrl() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      familyGroupId,
+      payload,
+    }: {
+      familyGroupId: number;
+      payload: ImportRecipeFromUrlPayload;
+    }) => importRecipeFromUrl(familyGroupId, payload),
     onSuccess: (recipe, { familyGroupId }) => {
       queryClient.setQueryData(recipeKeys.detail(recipe.id), recipe);
       invalidateRecipeQueries(queryClient, familyGroupId);

--- a/apps/mobile/types/recipe.ts
+++ b/apps/mobile/types/recipe.ts
@@ -26,6 +26,10 @@ export interface CreateRecipePayload {
   ingredients?: RecipeIngredient[];
 }
 
+export interface ImportRecipeFromUrlPayload {
+  url: string;
+}
+
 export interface UpdateRecipePayload {
   name?: string;
   description?: string;

--- a/frontend/cypress/e2e/recipes/recipes.cy.ts
+++ b/frontend/cypress/e2e/recipes/recipes.cy.ts
@@ -18,6 +18,7 @@ describe('Recipes', () => {
   it('creates, edits and deletes a recipe', () => {
     cy.get('[data-testid="recipes-new-button"]').click();
     cy.location('pathname').should('eq', '/recipes/create');
+    cy.get('[data-testid="recipe-create-method-manual"]').click();
 
     cy.get('[data-testid="recipe-form-name-input"]').type('Cypress Chilli');
     cy.get('[data-testid="recipe-form-description-input"]').type('A simple chilli.');

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -117,6 +117,27 @@
   "Unit": "Unit",
   "Create Recipe": "Create Recipe",
   "Save Changes": "Save Changes",
+  "recipeImport": {
+    "chooseMethodTitle": "How would you like to add this recipe?",
+    "chooseMethodDescription": "Create it by hand or import it from a recipe website.",
+    "manualOptionTitle": "Create manually",
+    "manualOptionDescription": "Start with an empty recipe form.",
+    "importOptionTitle": "Import from URL",
+    "importOptionDescription": "Paste a recipe link and we'll pull in what we can.",
+    "changeMethod": "Change method",
+    "title": "Import recipe from URL",
+    "description": "Paste a link to a recipe page and we'll create a recipe for your family.",
+    "urlLabel": "Recipe URL",
+    "urlPlaceholder": "https://example.com/your-recipe",
+    "submit": "Import Recipe",
+    "loadingTitle": "Importing recipe...",
+    "genericError": "Failed to import recipe",
+    "progress": {
+      "validating": "Validating the link...",
+      "fetching": "Fetching the recipe page...",
+      "creating": "Creating your recipe..."
+    }
+  },
   "Delete Recipe": "Delete Recipe",
   "Are you sure you want to delete this recipe? It will also be removed from any meal diary entries.": "Are you sure you want to delete this recipe? It will also be removed from any meal diary entries.",
   "Cancel": "Cancel",

--- a/frontend/pages/recipes/create.vue
+++ b/frontend/pages/recipes/create.vue
@@ -23,17 +23,127 @@
       </div>
     </div>
 
-    <RecipeForm
-      v-else
-      :submitLabel="$t('Create Recipe')"
-      :isLoading="recipeStore.loading"
-      @submit="handleCreate"
-      @cancel="router.push('/recipes')"
-    />
+    <div v-else class="space-y-4">
+      <button
+        v-if="creationMode"
+        class="btn btn-outline btn-sm"
+        @click="handleOpenCreationOptions"
+      >
+        {{ $t('recipeImport.changeMethod') }}
+      </button>
+
+      <div v-if="creationMode === 'import'" class="card bg-base-200 border border-base-300">
+        <div class="card-body gap-4">
+          <div>
+            <h2 class="card-title">{{ $t('recipeImport.title') }}</h2>
+            <p class="text-sm text-base-content/70">{{ $t('recipeImport.description') }}</p>
+          </div>
+
+          <label class="form-control">
+            <span class="label">
+              <span class="label-text font-semibold">{{ $t('recipeImport.urlLabel') }}</span>
+            </span>
+            <input
+              v-model="importUrl"
+              type="url"
+              class="input input-bordered w-full"
+              data-testid="recipe-import-url-input"
+              :placeholder="$t('recipeImport.urlPlaceholder')"
+              :disabled="isImporting"
+            />
+          </label>
+
+          <div v-if="importError" class="alert alert-error" data-testid="recipe-import-error">
+            <span>{{ importError }}</span>
+          </div>
+
+          <div
+            v-if="isImporting"
+            class="alert alert-info items-start"
+            data-testid="recipe-import-loading"
+          >
+            <span class="loading loading-spinner loading-sm mt-0.5"></span>
+            <div>
+              <div class="font-medium">{{ $t('recipeImport.loadingTitle') }}</div>
+              <div class="text-sm">{{ importProgressMessage }}</div>
+            </div>
+          </div>
+
+          <div class="flex justify-end gap-2">
+            <button class="btn btn-ghost" :disabled="isImporting" @click="router.push('/recipes')">
+              {{ $t('Cancel') }}
+            </button>
+            <button
+              class="btn btn-primary"
+              data-testid="recipe-import-submit-button"
+              :disabled="!canSubmitImport || isImporting"
+              @click="handleImportRecipe"
+            >
+              <span v-if="isImporting" class="loading loading-spinner loading-sm"></span>
+              <span>{{ $t('recipeImport.submit') }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <RecipeForm
+        v-else-if="creationMode === 'manual'"
+        :submitLabel="$t('Create Recipe')"
+        :isLoading="recipeStore.loading"
+        @submit="handleCreate"
+        @cancel="router.push('/recipes')"
+      />
+    </div>
+
+    <dialog
+      ref="creationOptionsDialog"
+      class="modal"
+      data-testid="recipe-create-method-dialog"
+      @close="handleDismissCreationOptions"
+    >
+      <div class="modal-box space-y-4">
+        <h2 class="text-xl font-semibold">{{ $t('recipeImport.chooseMethodTitle') }}</h2>
+        <p class="text-sm text-base-content/70">{{ $t('recipeImport.chooseMethodDescription') }}</p>
+
+        <div class="grid gap-3">
+          <button
+            class="btn btn-outline justify-start h-auto py-4"
+            data-testid="recipe-create-method-manual"
+            @click="handleSelectCreationMode('manual')"
+          >
+            <div class="text-left">
+              <div class="font-semibold">{{ $t('recipeImport.manualOptionTitle') }}</div>
+              <div class="text-xs text-base-content/70">{{ $t('recipeImport.manualOptionDescription') }}</div>
+            </div>
+          </button>
+          <button
+            class="btn btn-outline justify-start h-auto py-4"
+            data-testid="recipe-create-method-import"
+            @click="handleSelectCreationMode('import')"
+          >
+            <div class="text-left">
+              <div class="font-semibold">{{ $t('recipeImport.importOptionTitle') }}</div>
+              <div class="text-xs text-base-content/70">{{ $t('recipeImport.importOptionDescription') }}</div>
+            </div>
+          </button>
+        </div>
+
+        <div class="modal-action">
+          <form method="dialog">
+            <button class="btn btn-ghost" @click="handleDismissCreationOptions">
+              {{ $t('Cancel') }}
+            </button>
+          </form>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button @click="handleDismissCreationOptions">close</button>
+      </form>
+    </dialog>
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 definePageMeta({
   middleware: 'auth'
 });
@@ -41,16 +151,68 @@ definePageMeta({
 import { useRecipeStore } from '~/stores/recipe';
 import { useUserStore } from '~/stores/user';
 import RecipeForm from '~/components/recipe/RecipeForm.vue';
-import { extractEntitlementError } from '~/utils/httpError';
+import { extractEntitlementError, extractErrorMessage } from '~/utils/httpError';
 
 const router = useRouter();
 const recipeStore = useRecipeStore();
 const userStore = useUserStore();
+const { t } = useI18n();
 const { track } = useAnalytics();
 const { hasFeature, refreshEntitlements } = useEntitlements();
 const { openPaywall } = usePaywall();
 
 const canCreateRecipe = hasFeature('recipes');
+const creationMode = ref<'manual' | 'import' | null>(null);
+const creationOptionsDialog = ref<HTMLDialogElement | null>(null);
+const importUrl = ref('');
+const importError = ref('');
+const isImporting = ref(false);
+const importProgressStep = ref(0);
+let importProgressTimeouts: ReturnType<typeof setTimeout>[] = [];
+
+const importProgressKeys = [
+  'recipeImport.progress.validating',
+  'recipeImport.progress.fetching',
+  'recipeImport.progress.creating',
+] as const;
+
+const importProgressMessage = computed(() => t(importProgressKeys[importProgressStep.value]));
+const canSubmitImport = computed(() => importUrl.value.trim().length > 0);
+
+const clearImportProgress = () => {
+  importProgressTimeouts.forEach(clearTimeout);
+  importProgressTimeouts = [];
+};
+
+const startImportProgress = () => {
+  clearImportProgress();
+  importProgressStep.value = 0;
+  importProgressTimeouts = [
+    setTimeout(() => {
+      importProgressStep.value = 1;
+    }, 900),
+    setTimeout(() => {
+      importProgressStep.value = 2;
+    }, 1800),
+  ];
+};
+
+const handleOpenCreationOptions = async () => {
+  await nextTick();
+  creationOptionsDialog.value?.showModal();
+};
+
+const handleSelectCreationMode = (mode: 'manual' | 'import') => {
+  creationMode.value = mode;
+  importError.value = '';
+  creationOptionsDialog.value?.close();
+};
+
+const handleDismissCreationOptions = () => {
+  if (!creationMode.value) {
+    router.push('/recipes');
+  }
+};
 
 const handleCreate = async (formData) => {
   if (!canCreateRecipe.value) {
@@ -75,11 +237,46 @@ const handleCreate = async (formData) => {
   }
 };
 
+const handleImportRecipe = async () => {
+  if (!canCreateRecipe.value || !canSubmitImport.value) {
+    return;
+  }
+
+  importError.value = '';
+  isImporting.value = true;
+  startImportProgress();
+
+  try {
+    const recipe = await recipeStore.importRecipeFromUrl({ url: importUrl.value.trim() });
+    if (recipe) {
+      track('recipe_imported');
+      router.push(`/recipes/${recipe.id}/edit`);
+    }
+  } catch (error) {
+    const entitlementError = extractEntitlementError(error);
+    if (entitlementError?.feature === 'recipes') {
+      openPaywall('recipes');
+      return;
+    }
+
+    importError.value = extractErrorMessage(error) || t('recipeImport.genericError');
+    console.error('Error importing recipe:', error);
+  } finally {
+    isImporting.value = false;
+    clearImportProgress();
+  }
+};
+
 onMounted(async () => {
   if (!userStore.user?.family_group_id) {
     await userStore.fetchUser();
   }
 
   await refreshEntitlements();
+  await handleOpenCreationOptions();
+});
+
+onBeforeUnmount(() => {
+  clearImportProgress();
 });
 </script>

--- a/frontend/server/api/recipes/import-from-url.post.ts
+++ b/frontend/server/api/recipes/import-from-url.post.ts
@@ -1,0 +1,12 @@
+import { apiFetch } from '~/server/utils/fetch';
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event);
+
+  const response = await apiFetch('/recipes/import-from-url', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  }, event);
+
+  return response;
+});

--- a/frontend/stores/recipe.ts
+++ b/frontend/stores/recipe.ts
@@ -1,7 +1,12 @@
 import { defineStore } from 'pinia';
 import { useUserStore } from './user';
 import { useApi } from '~/composables/useApi';
-import type { Recipe, RecipeIngredient, RecipeState } from '~/types/Recipe';
+import type {
+  ImportRecipeFromUrlPayload,
+  Recipe,
+  RecipeIngredient,
+  RecipeState,
+} from '~/types/Recipe';
 
 export const useRecipeStore = defineStore('recipe', {
   state: (): RecipeState => ({
@@ -81,6 +86,31 @@ export const useRecipeStore = defineStore('recipe', {
         return response;
       } catch (error) {
         console.error('Error creating recipe:', error);
+        throw error;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async importRecipeFromUrl({ url }: ImportRecipeFromUrlPayload) {
+      const userStore = useUserStore();
+      if (!userStore.user?.family_group_id) return;
+
+      try {
+        this.loading = true;
+        const { api } = useApi();
+        const response = await api<Recipe>('/api/recipes/import-from-url', {
+          method: 'POST',
+          body: {
+            family_group_id: userStore.user.family_group_id,
+            url,
+          },
+        });
+        this.recipes.push(response);
+        this.currentRecipe = response;
+        return response;
+      } catch (error) {
+        console.error('Error importing recipe:', error);
         throw error;
       } finally {
         this.loading = false;

--- a/frontend/types/Recipe.d.ts
+++ b/frontend/types/Recipe.d.ts
@@ -25,3 +25,7 @@ export interface RecipeState {
   loading: boolean;
   searchQuery: string;
 }
+
+export interface ImportRecipeFromUrlPayload {
+  url: string;
+}


### PR DESCRIPTION
Introduce a synchronous import endpoint with JSON-LD parsing and Vitest coverage, plus create-flow chooser UI that redirects imported recipes to edit.