### PR TITLE
Support Gousto category recipe URLs when importing.

### DIFF
--- a/api/services/recipe-import/__tests__/gousto.adapter.unit.test.ts
+++ b/api/services/recipe-import/__tests__/gousto.adapter.unit.test.ts
@@ -22,6 +22,12 @@ describe('recipe-import/gousto.adapter', () => {
         new URL('https://www.gousto.co.uk/cookbook/recipes/truffle-cacio-e-pepe-sauce-with-spinach-ricotta-ravioli')
       )
     ).toBe('truffle-cacio-e-pepe-sauce-with-spinach-ricotta-ravioli');
+
+    expect(
+      extractGoustoRecipeSlug(
+        new URL('https://www.gousto.co.uk/cookbook/chicken-recipes/sicilian-chicken-red-pepper-linguine')
+      )
+    ).toBe('sicilian-chicken-red-pepper-linguine');
   });
 
   it('parses quantity and unit from Gousto ingredient labels', () => {
@@ -140,5 +146,41 @@ describe('recipe-import/gousto.adapter', () => {
     );
     expect(draft.name).toBe('Imported Gousto recipe');
     expect(draft.ingredients).toEqual([{ name: 'Ravioli', quantity: 250, unit: 'g' }]);
+  });
+
+  it('routes category Gousto urls through the Gousto adapter', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{
+          attributes: {
+            name: 'Sicilian Chicken Red Pepper Linguine',
+            description: 'From Gousto API',
+            basics: [],
+            steps: [{ number: 1, instruction: '<p>Cook</p>' }],
+          },
+          relationships: {
+            ingredients: {
+              data: [{
+                id: '1',
+                type: 'ingredient',
+                labels: { for2: 'Chicken (320g)' },
+              }],
+            },
+          },
+        }],
+      }),
+    });
+
+    const draft = await parseRecipeFromUrl(
+      'https://www.gousto.co.uk/cookbook/chicken-recipes/sicilian-chicken-red-pepper-linguine',
+      fetchImpl as unknown as typeof fetch
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://production-api.gousto.co.uk/cookbook/v1/recipes/sicilian-chicken-red-pepper-linguine',
+      expect.any(Object)
+    );
+    expect(draft.name).toBe('Sicilian Chicken Red Pepper Linguine');
   });
 });

--- a/api/services/recipe-import/gousto.adapter.ts
+++ b/api/services/recipe-import/gousto.adapter.ts
@@ -45,7 +45,8 @@ export const isGoustoRecipeUrl = (url: URL): boolean => {
 };
 
 export const extractGoustoRecipeSlug = (url: URL): string | null => {
-  const match = url.pathname.match(/\/cookbook\/recipes\/([^/?#]+)/i);
+  // /cookbook/recipes/{slug} and /cookbook/{category}/{slug} (e.g. chicken-recipes)
+  const match = url.pathname.match(/\/cookbook\/(?:[^/]+\/)+([^/?#]+)\/?$/i);
   return match?.[1] ? decodeURIComponent(match[1]) : null;
 };
 


### PR DESCRIPTION
Extract the recipe slug from paths like /cookbook/chicken-recipes/{slug}, not only /cookbook/recipes/{slug}.